### PR TITLE
An alternative unsubscription approach using return functions

### DIFF
--- a/documentation/HowToAddAnEventToAClass.md
+++ b/documentation/HowToAddAnEventToAClass.md
@@ -37,12 +37,21 @@ myObject.onMyEvent.subscribe((s: MyClass, a: string) => {
 });
 ```
 
+An event handler can be unsubscribed like this:
+
+```
+let unsubscribe = myObject.onMyEvent.subscribe((s: MyClass, a: string) => {
+	alert(s);
+});
+unsubscribe();
+``` 
+
 ###Event methods
 The `IEvent<TSender, TArgs>`, `ISimple<TArgs>`, `EventDispatcher<TSender, TArgs>`, `SimpleEvenDispatcher<TArgs>` share the 
 same basic methods:
 
 - `subscribe(eventHandler)` - subscribes to the event by registring an event handler. The handler will be executed when
-the event is dispatched.
+the event is dispatched. The subscribe method returns a function that can be used to unsubscribe the eventHandler directly.
 - `unsubscribe(eventHandler)` - removes the subscription by removing the handler. This will stop the handler from being executed
 when the event is dispatched.
 

--- a/strongly-typed-events.d.ts
+++ b/strongly-typed-events.d.ts
@@ -38,13 +38,15 @@ export interface ISubscribable<THandlerType> {
     /**
      * Subscribe to the event.
      * @param fn The event handler that is called when the event is dispatched.
+     * @returns A function that unsubscribes the event handler from the event.
      */
-    subscribe(fn: THandlerType): void;
+    subscribe(fn: THandlerType): () => void;
     /**
      * Subscribe to the event.
      * @param fn The event handler that is called when the event is dispatched.
+     * @returns A function that unsubscribes the event handler from the event.
      */
-    sub(fn: THandlerType): void;
+    sub(fn: THandlerType): () => void;
     /**
      * Unsubscribe from the event.
      * @param fn The event handler that is will be unsubsribed from the event.
@@ -183,13 +185,15 @@ export declare abstract class DispatcherBase<TEventHandler> implements ISubscrib
     /**
      * Subscribe to the event dispatcher.
      * @param fn The event handler that is called when the event is dispatched.
+     * @returns A function that unsubscribes the event handler from the event.
      */
-    subscribe(fn: TEventHandler): void;
+    subscribe(fn: TEventHandler): () => void;
     /**
      * Subscribe to the event dispatcher.
      * @param fn The event handler that is called when the event is dispatched.
+     * @returns A function that unsubscribes the event handler from the event.
      */
-    sub(fn: TEventHandler): void;
+    sub(fn: TEventHandler): () => void;
     /**
      * Subscribe once to the event with the specified name.
      * @param fn The event handler that is called when the event is dispatched.
@@ -322,13 +326,15 @@ export declare class DispatcherWrapper<THandler> implements ISubscribable<THandl
     /**
      * Subscribe to the event dispatcher.
      * @param fn The event handler that is called when the event is dispatched.
+     * @returns A function that unsubscribes the event handler from the event.
      */
-    subscribe(fn: THandler): void;
+    subscribe(fn: THandler): () => void;
     /**
      * Subscribe to the event dispatcher.
      * @param fn The event handler that is called when the event is dispatched.
+     * @returns A function that unsubscribes the event handler from the event.
      */
-    sub(fn: THandler): void;
+    sub(fn: THandler): () => void;
     /**
      * Unsubscribe from the event dispatcher.
      * @param fn The event handler that is called when the event is dispatched.

--- a/strongly-typed-events.d.ts
+++ b/strongly-typed-events.d.ts
@@ -49,17 +49,17 @@ export interface ISubscribable<THandlerType> {
     sub(fn: THandlerType): () => void;
     /**
      * Unsubscribe from the event.
-     * @param fn The event handler that is will be unsubsribed from the event.
+     * @param fn The event handler that will be unsubsribed from the event.
      */
     unsubscribe(fn: THandlerType): void;
     /**
      * Unsubscribe from the event.
-     * @param fn The event handler that is will be unsubsribed from the event.
+     * @param fn The event handler that will be unsubsribed from the event.
      */
     unsub(fn: THandlerType): void;
     /**
      * Subscribes to the event only once.
-     * @param fn The event handler that is will be unsubsribed from the event.
+     * @param fn The event handler that is called when the event is dispatched.
      */
     one(fn: THandlerType): void;
     /**

--- a/strongly-typed-events.d.ts
+++ b/strongly-typed-events.d.ts
@@ -60,8 +60,9 @@ export interface ISubscribable<THandlerType> {
     /**
      * Subscribes to the event only once.
      * @param fn The event handler that is called when the event is dispatched.
+     * @returns A function that unsubscribes the event handler from the event.
      */
-    one(fn: THandlerType): void;
+    one(fn: THandlerType): () => void;
     /**
      * Checks it the event has a subscription for the specified handler.
      * @param fn The event handler.
@@ -197,8 +198,9 @@ export declare abstract class DispatcherBase<TEventHandler> implements ISubscrib
     /**
      * Subscribe once to the event with the specified name.
      * @param fn The event handler that is called when the event is dispatched.
+     * @returns A function that unsubscribes the event handler from the event.
      */
-    one(fn: TEventHandler): void;
+    one(fn: TEventHandler): () => void;
     /**
      * Checks it the event has a subscription for the specified handler.
      * @param fn The event handler.
@@ -349,7 +351,7 @@ export declare class DispatcherWrapper<THandler> implements ISubscribable<THandl
      * Subscribe once to the event with the specified name.
      * @param fn The event handler that is called when the event is dispatched.
      */
-    one(fn: THandler): void;
+    one(fn: THandler): () => void;
     /**
      * Checks it the event has a subscription for the specified handler.
      * @param fn The event handler.

--- a/strongly-typed-events.js
+++ b/strongly-typed-events.js
@@ -99,11 +99,16 @@ var DispatcherBase = /** @class */ (function () {
     /**
      * Subscribe once to the event with the specified name.
      * @param fn The event handler that is called when the event is dispatched.
+     * @returns A function that unsubscribes the event handler from the event.
      */
     DispatcherBase.prototype.one = function (fn) {
+        var _this = this;
         if (fn) {
             this._subscriptions.push(new Subscription(fn, true));
         }
+        return function () {
+            _this.unsubscribe(fn);
+        };
     };
     /**
      * Checks it the event has a subscription for the specified handler.
@@ -338,7 +343,7 @@ var DispatcherWrapper = /** @class */ (function () {
      * @param fn The event handler that is called when the event is dispatched.
      */
     DispatcherWrapper.prototype.one = function (fn) {
-        this._one(fn);
+        return this._one(fn);
     };
     /**
      * Checks it the event has a subscription for the specified handler.

--- a/strongly-typed-events.js
+++ b/strongly-typed-events.js
@@ -1,3 +1,4 @@
+"use strict";
 /*!
  * Strongly Typed Events for TypeScript - 1.0.1
  * https://github.com/KeesCBakker/StronlyTypedEvents/
@@ -6,19 +7,24 @@
  * Copyright Kees C. Bakker / KeesTalksTech
  * Released under the MIT license
  */
-"use strict";
-var __extends = (this && this.__extends) || function (d, b) {
-    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
-    function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
-};
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = Object.setPrototypeOf ||
+        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
 "use strict";
 /**
  * Stores a handler. Manages execution meta data.
  * @class Subscription
  * @template TEventHandler
  */
-var Subscription = (function () {
+var Subscription = /** @class */ (function () {
     /**
      * Creates an instance of Subscription.
      *
@@ -63,7 +69,7 @@ exports.Subscription = Subscription;
  * the type of event that should be exposed. Use the asEvent to expose the
  * dispatcher as event.
  */
-var DispatcherBase = (function () {
+var DispatcherBase = /** @class */ (function () {
     function DispatcherBase() {
         this._wrap = new DispatcherWrapper(this);
         this._subscriptions = new Array();
@@ -71,18 +77,24 @@ var DispatcherBase = (function () {
     /**
      * Subscribe to the event dispatcher.
      * @param fn The event handler that is called when the event is dispatched.
+     * @returns A function that unsubscribes the event handler from the event.
      */
     DispatcherBase.prototype.subscribe = function (fn) {
+        var _this = this;
         if (fn) {
             this._subscriptions.push(new Subscription(fn, false));
         }
+        return function () {
+            _this.unsubscribe(fn);
+        };
     };
     /**
      * Subscribe to the event dispatcher.
      * @param fn The event handler that is called when the event is dispatched.
+     * @returns A function that unsubscribes the event handler from the event.
      */
     DispatcherBase.prototype.sub = function (fn) {
-        this.subscribe(fn);
+        return this.subscribe(fn);
     };
     /**
      * Subscribe once to the event with the specified name.
@@ -171,7 +183,7 @@ exports.DispatcherBase = DispatcherBase;
  * Dispatcher implementation for events. Can be used to subscribe, unsubscribe
  * or dispatch events. Use the ToEvent() method to expose the event.
  */
-var EventDispatcher = (function (_super) {
+var EventDispatcher = /** @class */ (function (_super) {
     __extends(EventDispatcher, _super);
     /**
      * Creates a new EventDispatcher instance.
@@ -209,7 +221,7 @@ exports.EventDispatcher = EventDispatcher;
  * The dispatcher handles the storage of subsciptions and facilitates
  * subscription, unsubscription and dispatching of a simple event
  */
-var SimpleEventDispatcher = (function (_super) {
+var SimpleEventDispatcher = /** @class */ (function (_super) {
     __extends(SimpleEventDispatcher, _super);
     /**
      * Creates a new SimpleEventDispatcher instance.
@@ -245,7 +257,7 @@ exports.SimpleEventDispatcher = SimpleEventDispatcher;
  * The dispatcher handles the storage of subsciptions and facilitates
  * subscription, unsubscription and dispatching of a signal event.
  */
-var SignalDispatcher = (function (_super) {
+var SignalDispatcher = /** @class */ (function (_super) {
     __extends(SignalDispatcher, _super);
     /**
      * Creates a new SignalDispatcher instance.
@@ -279,7 +291,7 @@ exports.SignalDispatcher = SignalDispatcher;
  * Hides the implementation of the event dispatcher. Will expose methods that
  * are relevent to the event.
  */
-var DispatcherWrapper = (function () {
+var DispatcherWrapper = /** @class */ (function () {
     /**
      * Creates a new EventDispatcherWrapper instance.
      * @param dispatcher The dispatcher.
@@ -294,16 +306,18 @@ var DispatcherWrapper = (function () {
     /**
      * Subscribe to the event dispatcher.
      * @param fn The event handler that is called when the event is dispatched.
+     * @returns A function that unsubscribes the event handler from the event.
      */
     DispatcherWrapper.prototype.subscribe = function (fn) {
-        this._subscribe(fn);
+        return this._subscribe(fn);
     };
     /**
      * Subscribe to the event dispatcher.
      * @param fn The event handler that is called when the event is dispatched.
+     * @returns A function that unsubscribes the event handler from the event.
      */
     DispatcherWrapper.prototype.sub = function (fn) {
-        this.subscribe(fn);
+        return this.subscribe(fn);
     };
     /**
      * Unsubscribe from the event dispatcher.
@@ -345,7 +359,7 @@ exports.DispatcherWrapper = DispatcherWrapper;
 /**
  * Base class for event lists classes. Implements the get and remove.
  */
-var EventListBase = (function () {
+var EventListBase = /** @class */ (function () {
     function EventListBase() {
         this._events = {};
     }
@@ -376,7 +390,7 @@ exports.EventListBase = EventListBase;
  * Storage class for multiple events that are accessible by name.
  * Events dispatchers are automatically created.
  */
-var EventList = (function (_super) {
+var EventList = /** @class */ (function (_super) {
     __extends(EventList, _super);
     /**
      * Creates a new EventList instance.
@@ -397,7 +411,7 @@ exports.EventList = EventList;
  * Storage class for multiple simple events that are accessible by name.
  * Events dispatchers are automatically created.
  */
-var SimpleEventList = (function (_super) {
+var SimpleEventList = /** @class */ (function (_super) {
     __extends(SimpleEventList, _super);
     /**
      * Creates a new SimpleEventList instance.
@@ -418,7 +432,7 @@ exports.SimpleEventList = SimpleEventList;
  * Storage class for multiple signal events that are accessible by name.
  * Events dispatchers are automatically created.
  */
-var SignalList = (function (_super) {
+var SignalList = /** @class */ (function (_super) {
     __extends(SignalList, _super);
     /**
      * Creates a new SignalList instance.
@@ -438,7 +452,7 @@ exports.SignalList = SignalList;
 /**
  * Extends objects with event handling capabilities.
  */
-var EventHandlingBase = (function () {
+var EventHandlingBase = /** @class */ (function () {
     function EventHandlingBase() {
         this._events = new EventList();
     }
@@ -506,7 +520,7 @@ exports.EventHandlingBase = EventHandlingBase;
 /**
  * Extends objects with simple event handling capabilities.
  */
-var SimpleEventHandlingBase = (function () {
+var SimpleEventHandlingBase = /** @class */ (function () {
     function SimpleEventHandlingBase() {
         this._events = new SimpleEventList();
     }
@@ -571,7 +585,7 @@ exports.SimpleEventHandlingBase = SimpleEventHandlingBase;
 /**
  * Extends objects with signal event handling capabilities.
  */
-var SignalHandlingBase = (function () {
+var SignalHandlingBase = /** @class */ (function () {
     function SignalHandlingBase() {
         this._events = new SignalList();
     }
@@ -683,5 +697,4 @@ var StronglyTypedEventsStatic = {
 };
 exports.IStronglyTypedEvents = StronglyTypedEventsStatic;
 var _e = exports.IStronglyTypedEvents;
-Object.defineProperty(exports, "__esModule", { value: true });
 exports.default = StronglyTypedEventsStatic;

--- a/strongly-typed-events.ts
+++ b/strongly-typed-events.ts
@@ -43,14 +43,16 @@ export interface ISubscribable<THandlerType> {
     /** 
      * Subscribe to the event.
      * @param fn The event handler that is called when the event is dispatched.
+     * @returns A function that unsubscribes the event handler from the event.
      */
-    subscribe(fn: THandlerType): void;
+    subscribe(fn: THandlerType): () => void;
 
     /** 
      * Subscribe to the event.
      * @param fn The event handler that is called when the event is dispatched.
+     * @returns A function that unsubscribes the event handler from the event.
      */
-    sub(fn: THandlerType): void;
+    sub(fn: THandlerType): () => void;
 
     /** 
      * Unsubscribe from the event.
@@ -229,19 +231,24 @@ export abstract class DispatcherBase<TEventHandler> implements ISubscribable<TEv
     /**
      * Subscribe to the event dispatcher.
      * @param fn The event handler that is called when the event is dispatched.
+     * @returns A function that unsubscribes the event handler from the event.
      */
-    public subscribe(fn: TEventHandler): void {
+    public subscribe(fn: TEventHandler): () => void {
         if (fn) {
             this._subscriptions.push(new Subscription<TEventHandler>(fn, false));
         }
+        return () => {
+            this.unsubscribe(fn);
+        };
     }
 
     /**
      * Subscribe to the event dispatcher.
      * @param fn The event handler that is called when the event is dispatched.
+     * @returns A function that unsubscribes the event handler from the event.
      */
-    public sub(fn: TEventHandler): void {
-        this.subscribe(fn);
+    public sub(fn: TEventHandler): () => void {
+        return this.subscribe(fn);
     }
 
     /** 
@@ -382,7 +389,7 @@ export class EventDispatcher<TSender, TArgs> extends DispatcherBase<IEventHandle
 
 /**
  * The dispatcher handles the storage of subsciptions and facilitates
- * subscription, unsubscription and dispatching of a simple event 
+ * subscription, unsubscription and dispatching of a simple event
  */
 export class SimpleEventDispatcher<TArgs> extends DispatcherBase<ISimpleEventHandler<TArgs>> implements ISimpleEvent<TArgs>
 {
@@ -460,7 +467,7 @@ export class SignalDispatcher extends DispatcherBase<ISignalHandler> implements 
  */
 export class DispatcherWrapper<THandler> implements ISubscribable<THandler>
 {
-    private _subscribe: (fn: THandler) => void;
+    private _subscribe: (fn: THandler) => () => void;
     private _unsubscribe: (fn: THandler) => void;
     private _one: (fn: THandler) => void;
     private _has: (fn: THandler) => boolean;
@@ -481,17 +488,19 @@ export class DispatcherWrapper<THandler> implements ISubscribable<THandler>
     /**
      * Subscribe to the event dispatcher.
      * @param fn The event handler that is called when the event is dispatched.
+     * @returns A function that unsubscribes the event handler from the event.
      */
-    public subscribe(fn: THandler): void {
-        this._subscribe(fn);
+    public subscribe(fn: THandler): () => void {
+        return this._subscribe(fn);
     }
 
     /**
      * Subscribe to the event dispatcher.
      * @param fn The event handler that is called when the event is dispatched.
+     * @returns A function that unsubscribes the event handler from the event.
      */
-    public sub(fn: THandler): void {
-        this.subscribe(fn);
+    public sub(fn: THandler): () => void {
+        return this.subscribe(fn);
     }
 
     /**
@@ -535,7 +544,7 @@ export class DispatcherWrapper<THandler> implements ISubscribable<THandler>
 }
 
 /**
- * Base class for event lists classes. Implements the get and remove. 
+ * Base class for event lists classes. Implements the get and remove.
  */
 export abstract class EventListBase<TEventDispatcher> {
 

--- a/strongly-typed-events.ts
+++ b/strongly-typed-events.ts
@@ -56,19 +56,19 @@ export interface ISubscribable<THandlerType> {
 
     /** 
      * Unsubscribe from the event.
-     * @param fn The event handler that is will be unsubsribed from the event.
+     * @param fn The event handler that will be unsubsribed from the event.
      */
     unsubscribe(fn: THandlerType): void;
 
     /** 
      * Unsubscribe from the event.
-     * @param fn The event handler that is will be unsubsribed from the event.
+     * @param fn The event handler that will be unsubsribed from the event.
      */
     unsub(fn: THandlerType): void;
 
     /**
      * Subscribes to the event only once.
-     * @param fn The event handler that is will be unsubsribed from the event.
+     * @param fn The event handler that is called when the event is dispatched.
      */
     one(fn: THandlerType): void;
 

--- a/strongly-typed-events.ts
+++ b/strongly-typed-events.ts
@@ -69,8 +69,9 @@ export interface ISubscribable<THandlerType> {
     /**
      * Subscribes to the event only once.
      * @param fn The event handler that is called when the event is dispatched.
+     * @returns A function that unsubscribes the event handler from the event.
      */
-    one(fn: THandlerType): void;
+    one(fn: THandlerType): () => void;
 
     /**
      * Checks it the event has a subscription for the specified handler.
@@ -254,11 +255,15 @@ export abstract class DispatcherBase<TEventHandler> implements ISubscribable<TEv
     /** 
      * Subscribe once to the event with the specified name.
      * @param fn The event handler that is called when the event is dispatched.
+     * @returns A function that unsubscribes the event handler from the event.
      */
-    public one(fn: TEventHandler): void {
+    public one(fn: TEventHandler): () => void {
         if (fn) {
             this._subscriptions.push(new Subscription<TEventHandler>(fn, true));
         }
+        return () => {
+            this.unsubscribe(fn);
+        };
     }
 
     /**
@@ -469,7 +474,7 @@ export class DispatcherWrapper<THandler> implements ISubscribable<THandler>
 {
     private _subscribe: (fn: THandler) => () => void;
     private _unsubscribe: (fn: THandler) => void;
-    private _one: (fn: THandler) => void;
+    private _one: (fn: THandler) => () => void;
     private _has: (fn: THandler) => boolean;
     private _clear: () => void;
 
@@ -523,8 +528,8 @@ export class DispatcherWrapper<THandler> implements ISubscribable<THandler>
      * Subscribe once to the event with the specified name.
      * @param fn The event handler that is called when the event is dispatched.
      */
-    public one(fn: THandler): void {
-        this._one(fn);
+    public one(fn: THandler): () => void {
+        return this._one(fn);
     }
 
     /**

--- a/test/classic-test.js
+++ b/test/classic-test.js
@@ -1,15 +1,21 @@
 'use strict';
-var __extends = (this && this.__extends) || function (d, b) {
-    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
-    function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
-};
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = Object.setPrototypeOf ||
+        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
 var chai_1 = require("chai");
 var strongly_typed_events_1 = require("../strongly-typed-events");
 describe("Strongly Typed Events", function () {
     describe("Event", function () {
         it("Subscribe / unsubscribe - event as property", function () {
-            var MyEventTester = (function () {
+            var MyEventTester = /** @class */ (function () {
                 function MyEventTester() {
                     this._myEvent = new strongly_typed_events_1.EventDispatcher();
                 }
@@ -40,7 +46,7 @@ describe("Strongly Typed Events", function () {
             chai_1.expect(eventHandlerResult, 'The eventHandlerResult should still be "Test2".').to.equal('Test2');
         });
         it("Subscribe / unsubscribe - event on interface", function () {
-            var MyEventTester = (function () {
+            var MyEventTester = /** @class */ (function () {
                 function MyEventTester() {
                     this._myEvent = new strongly_typed_events_1.EventDispatcher();
                 }
@@ -80,7 +86,7 @@ describe("Strongly Typed Events", function () {
             chai_1.expect(result, 'The result should be "Testing 42".').to.equal('Testing 42');
         });
         it('EventHandlingBase', function () {
-            var MyTester = (function (_super) {
+            var MyTester = /** @class */ (function (_super) {
                 __extends(MyTester, _super);
                 function MyTester() {
                     return _super !== null && _super.apply(this, arguments) || this;
@@ -102,13 +108,13 @@ describe("Strongly Typed Events", function () {
             chai_1.expect(result, 'The result should be "Testing 789".').to.equal('Testing 789');
         });
         it('Dispatcher', function () {
-            var Source = (function () {
+            var Source = /** @class */ (function () {
                 function Source(name) {
                     this.name = name;
                 }
                 return Source;
             }());
-            var Argument = (function () {
+            var Argument = /** @class */ (function () {
                 function Argument(name) {
                     this.name = name;
                 }
@@ -138,10 +144,24 @@ describe("Strongly Typed Events", function () {
             dispatcher.dispatchAsync(null, 1);
             chai_1.expect(i, 'Because of async dispatch, i should be 0.').to.equal(0);
         });
+        it('Unsubscribe event handler after dispatching 2 times.', function () {
+            var dispatcher = new strongly_typed_events_1.EventDispatcher();
+            var i = 0;
+            var unsub = dispatcher.subscribe(function (s, a) {
+                i += a;
+                if (i == 3) {
+                    unsub();
+                }
+            });
+            dispatcher.dispatch(null, 1);
+            dispatcher.dispatch(null, 2);
+            dispatcher.dispatch(null, 4);
+            chai_1.expect(i, 'Because of unsubscribing, i should be 3.').to.equal(3);
+        });
     });
     describe("Simple Event", function () {
         it("Subscribe / unsubscribe - simple event as property", function () {
-            var MyEventTester = (function () {
+            var MyEventTester = /** @class */ (function () {
                 function MyEventTester() {
                     this._myEvent = new strongly_typed_events_1.SimpleEventDispatcher();
                 }
@@ -170,7 +190,7 @@ describe("Strongly Typed Events", function () {
             chai_1.expect(result, 'Result should still be "Test1" because of unsubscribe.').to.equal('Test1');
         });
         it("Subscribe / unsubscribe - simple event on interface", function () {
-            var MyEventTester = (function () {
+            var MyEventTester = /** @class */ (function () {
                 function MyEventTester() {
                     this._myEvent = new strongly_typed_events_1.SimpleEventDispatcher();
                 }
@@ -210,7 +230,7 @@ describe("Strongly Typed Events", function () {
             chai_1.expect(result, 'Result of dispatch of interface should be "Testing 42".').to.equal('Testing 42');
         });
         it('SimpleEventHandlingBase', function () {
-            var MyTester = (function (_super) {
+            var MyTester = /** @class */ (function (_super) {
                 __extends(MyTester, _super);
                 function MyTester() {
                     return _super !== null && _super.apply(this, arguments) || this;
@@ -232,7 +252,7 @@ describe("Strongly Typed Events", function () {
             chai_1.expect(result, 'The result should be "Testing 789".').to.equal('Testing 789');
         });
         it('Dispatcher', function () {
-            var Argument = (function () {
+            var Argument = /** @class */ (function () {
                 function Argument(name) {
                     this.name = name;
                 }
@@ -258,10 +278,24 @@ describe("Strongly Typed Events", function () {
             dispatcher.dispatchAsync(1);
             chai_1.expect(i, 'Because of async dispatch, i should be 0.').to.equal(0);
         });
+        it('Unsubscribe event handler after dispatching 2 times.', function () {
+            var dispatcher = new strongly_typed_events_1.SimpleEventDispatcher();
+            var i = 0;
+            var unsub = dispatcher.subscribe(function (a) {
+                i += a;
+                if (i == 3) {
+                    unsub();
+                }
+            });
+            dispatcher.dispatch(1);
+            dispatcher.dispatch(2);
+            dispatcher.dispatch(4);
+            chai_1.expect(i, 'Because of unsubscribing, i should be 3.').to.equal(3);
+        });
     });
     describe('Signal', function () {
         it("Subscribe / unsubscribe - signal as property", function () {
-            var MyEventTester = (function () {
+            var MyEventTester = /** @class */ (function () {
                 function MyEventTester() {
                     this._myEvent = new strongly_typed_events_1.SignalDispatcher();
                 }
@@ -290,7 +324,7 @@ describe("Strongly Typed Events", function () {
             chai_1.expect(i, 'i should still be 1 because of unsubscribe.').to.equal(1);
         });
         it("Subscribe / unsubscribe - signal on interface", function () {
-            var MyEventTester = (function () {
+            var MyEventTester = /** @class */ (function () {
                 function MyEventTester() {
                     this._myEvent = new strongly_typed_events_1.SignalDispatcher();
                 }
@@ -334,7 +368,7 @@ describe("Strongly Typed Events", function () {
             chai_1.expect(i, 'i should be 90.').to.equal(90);
         });
         it('SignalHandlingBase', function () {
-            var MyTester = (function (_super) {
+            var MyTester = /** @class */ (function (_super) {
                 __extends(MyTester, _super);
                 function MyTester() {
                     return _super !== null && _super.apply(this, arguments) || this;
@@ -365,6 +399,20 @@ describe("Strongly Typed Events", function () {
             });
             dispatcher.dispatchAsync();
             chai_1.expect(i, 'Because of async dispatch, i should be 0.').to.equal(0);
+        });
+        it('Unsubscribe event handler after dispatching 2 times.', function () {
+            var dispatcher = new strongly_typed_events_1.SignalDispatcher();
+            var i = 0;
+            var unsub = dispatcher.subscribe(function () {
+                i++;
+                if (i == 2) {
+                    unsub();
+                }
+            });
+            dispatcher.dispatch();
+            dispatcher.dispatch();
+            dispatcher.dispatch();
+            chai_1.expect(i, 'Because of unsubscribing, i should be 2.').to.equal(2);
         });
     });
     describe("One", function () {

--- a/test/classic-test.ts
+++ b/test/classic-test.ts
@@ -175,6 +175,26 @@ describe("Strongly Typed Events", function () {
             dispatcher.dispatchAsync(null, 1);
             expect(i, 'Because of async dispatch, i should be 0.').to.equal(0);
         });
+
+        it('Unsubscribe event handler after dispatching 2 times.', function () {
+
+            let dispatcher = new EventDispatcher<any, number>();
+
+            let i = 0;
+
+            let unsub = dispatcher.subscribe((s, a) => {
+                i += a;
+                if(i == 3) {
+                    unsub();
+                }
+            });
+
+            dispatcher.dispatch(null, 1);
+            dispatcher.dispatch(null, 2);
+            dispatcher.dispatch(null, 4);
+
+            expect(i, 'Because of unsubscribing, i should be 3.').to.equal(3);
+        });
     });
 
     describe("Simple Event", function () {
@@ -322,6 +342,26 @@ describe("Strongly Typed Events", function () {
             dispatcher.dispatchAsync(1);
             expect(i, 'Because of async dispatch, i should be 0.').to.equal(0);
         });
+
+        it('Unsubscribe event handler after dispatching 2 times.', function () {
+
+            let dispatcher = new SimpleEventDispatcher<number>();
+
+            let i = 0;
+
+            let unsub = dispatcher.subscribe((a) => {
+                i += a;
+                if(i == 3) {
+                    unsub();
+                }
+            });
+
+            dispatcher.dispatch(1);
+            dispatcher.dispatch(2);
+            dispatcher.dispatch(4);
+
+            expect(i, 'Because of unsubscribing, i should be 3.').to.equal(3);
+        });
     });
 
 
@@ -458,6 +498,26 @@ describe("Strongly Typed Events", function () {
 
             dispatcher.dispatchAsync();
             expect(i, 'Because of async dispatch, i should be 0.').to.equal(0);
+        });
+
+        it('Unsubscribe event handler after dispatching 2 times.', function () {
+
+            let dispatcher = new SignalDispatcher();
+
+            let i = 0;
+
+            let unsub = dispatcher.subscribe(() => {
+                i++;
+                if(i == 2) {
+                    unsub();
+                }
+            });
+
+            dispatcher.dispatch();
+            dispatcher.dispatch();
+            dispatcher.dispatch();
+
+            expect(i, 'Because of unsubscribing, i should be 2.').to.equal(2);
         });
     });
 

--- a/test/event-test.js
+++ b/test/event-test.js
@@ -150,6 +150,20 @@ describe("Strongly Typed Events - Event", function () {
             chai_1.expect(resultDummy, 'resultDummy should be empty.').to.equal(null);
             chai_1.expect(resultNr, 'resultNr should be 0.').to.equal(0);
         });
+        it("Unsubscribing from event dispatcher using one's return function.", function () {
+            var carolus = new Dummy('Carolus');
+            var dispatcher = new strongly_typed_events_1.EventDispatcher();
+            var resultNr = 0;
+            var resultDummy = null;
+            var unsub = dispatcher.one(function (dummy, nr) {
+                resultDummy = dummy;
+                resultNr += nr;
+            });
+            unsub();
+            dispatcher.dispatch(carolus, 6);
+            chai_1.expect(resultDummy, 'resultDummy should be empty.').to.equal(null);
+            chai_1.expect(resultNr, 'resultNr should be 0.').to.equal(0);
+        });
         it("Has no event.", function () {
             var fn = function (dummy, nr) { };
             var dispatcher = new strongly_typed_events_1.EventDispatcher();

--- a/test/event-test.js
+++ b/test/event-test.js
@@ -1,7 +1,8 @@
 'use strict';
+Object.defineProperty(exports, "__esModule", { value: true });
 var chai_1 = require("chai");
 var strongly_typed_events_1 = require("../strongly-typed-events");
-var Dummy = (function () {
+var Dummy = /** @class */ (function () {
     function Dummy(name) {
     }
     return Dummy;
@@ -102,6 +103,34 @@ describe("Strongly Typed Events - Event", function () {
             };
             dispatcher.sub(fn);
             dispatcher.unsub(fn);
+            dispatcher.dispatch(carolus, 6);
+            chai_1.expect(resultDummy, 'resultDummy should be empty.').to.equal(null);
+            chai_1.expect(resultNr, 'resultNr should be 0.').to.equal(0);
+        });
+        it("Unsubscribing from event dispatcher using subscribe's return function.", function () {
+            var carolus = new Dummy('Carolus');
+            var dispatcher = new strongly_typed_events_1.EventDispatcher();
+            var resultNr = 0;
+            var resultDummy = null;
+            var unsub = dispatcher.subscribe(function (dummy, nr) {
+                resultDummy = dummy;
+                resultNr += nr;
+            });
+            unsub();
+            dispatcher.dispatch(carolus, 6);
+            chai_1.expect(resultDummy, 'resultDummy should be empty.').to.equal(null);
+            chai_1.expect(resultNr, 'resultNr should be 0.').to.equal(0);
+        });
+        it("Unsubscribing from event dispatcher using sub's return function.", function () {
+            var carolus = new Dummy('Carolus');
+            var dispatcher = new strongly_typed_events_1.EventDispatcher();
+            var resultNr = 0;
+            var resultDummy = null;
+            var unsub = dispatcher.sub(function (dummy, nr) {
+                resultDummy = dummy;
+                resultNr += nr;
+            });
+            unsub();
             dispatcher.dispatch(carolus, 6);
             chai_1.expect(resultDummy, 'resultDummy should be empty.').to.equal(null);
             chai_1.expect(resultNr, 'resultNr should be 0.').to.equal(0);

--- a/test/event-test.ts
+++ b/test/event-test.ts
@@ -160,6 +160,44 @@ describe("Strongly Typed Events - Event", function () {
             expect(resultNr, 'resultNr should be 0.').to.equal(0);
         });
 
+        it("Unsubscribing from event dispatcher using subscribe's return function.", function () {
+
+            var carolus = new Dummy('Carolus');
+
+            let dispatcher = new EventDispatcher<Dummy, number>();
+            let resultNr = 0;
+            let resultDummy: Dummy = null;
+
+            let unsub = dispatcher.subscribe((dummy: Dummy, nr: number) => {
+                resultDummy = dummy;
+                resultNr += nr;
+            });
+            unsub();
+            dispatcher.dispatch(carolus, 6);
+
+            expect(resultDummy, 'resultDummy should be empty.').to.equal(null);
+            expect(resultNr, 'resultNr should be 0.').to.equal(0);
+        });
+
+        it("Unsubscribing from event dispatcher using sub's return function.", function () {
+
+            var carolus = new Dummy('Carolus');
+
+            let dispatcher = new EventDispatcher<Dummy, number>();
+            let resultNr = 0;
+            let resultDummy: Dummy = null;
+
+            let unsub = dispatcher.sub((dummy: Dummy, nr: number) => {
+                resultDummy = dummy;
+                resultNr += nr;
+            });
+            unsub();
+            dispatcher.dispatch(carolus, 6);
+
+            expect(resultDummy, 'resultDummy should be empty.').to.equal(null);
+            expect(resultNr, 'resultNr should be 0.').to.equal(0);
+        });
+
 
         it("Unsubscribing to a one subscription.", function () {
 

--- a/test/event-test.ts
+++ b/test/event-test.ts
@@ -220,6 +220,25 @@ describe("Strongly Typed Events - Event", function () {
             expect(resultNr, 'resultNr should be 0.').to.equal(0);
         });
 
+        it("Unsubscribing from event dispatcher using one's return function.", function () {
+
+            var carolus = new Dummy('Carolus');
+
+            let dispatcher = new EventDispatcher<Dummy, number>();
+            let resultNr = 0;
+            let resultDummy: Dummy = null;
+
+            let unsub = dispatcher.one((dummy: Dummy, nr: number) => {
+                resultDummy = dummy;
+                resultNr += nr;
+            });
+            unsub();
+            dispatcher.dispatch(carolus, 6);
+
+            expect(resultDummy, 'resultDummy should be empty.').to.equal(null);
+            expect(resultNr, 'resultNr should be 0.').to.equal(0);
+        });
+
 
         it("Has no event.", function () {
             var fn = (dummy: Dummy, nr: number) => { };

--- a/test/signal-test.js
+++ b/test/signal-test.js
@@ -1,4 +1,5 @@
 'use strict';
+Object.defineProperty(exports, "__esModule", { value: true });
 var chai_1 = require("chai");
 var strongly_typed_events_1 = require("../strongly-typed-events");
 describe("Strongly Typed Events - Signal", function () {
@@ -70,6 +71,26 @@ describe("Strongly Typed Events - Signal", function () {
             };
             dispatcher.sub(fn);
             dispatcher.unsub(fn);
+            dispatcher.dispatch();
+            chai_1.expect(resultNr, 'resultNr should be 0.').to.equal(0);
+        });
+        it("Unsubscribing from signal dispatcher using subscribe's return function.", function () {
+            var dispatcher = new strongly_typed_events_1.SignalDispatcher();
+            var resultNr = 0;
+            var unsub = dispatcher.subscribe(function () {
+                resultNr += 2;
+            });
+            unsub();
+            dispatcher.dispatch();
+            chai_1.expect(resultNr, 'resultNr should be 0.').to.equal(0);
+        });
+        it("Unsubscribing from signal dispatcher using sub's return function.", function () {
+            var dispatcher = new strongly_typed_events_1.SignalDispatcher();
+            var resultNr = 0;
+            var unsub = dispatcher.sub(function () {
+                resultNr += 2;
+            });
+            unsub();
             dispatcher.dispatch();
             chai_1.expect(resultNr, 'resultNr should be 0.').to.equal(0);
         });

--- a/test/signal-test.js
+++ b/test/signal-test.js
@@ -105,6 +105,16 @@ describe("Strongly Typed Events - Signal", function () {
             dispatcher.dispatch();
             chai_1.expect(resultNr, 'resultNr should be 0.').to.equal(0);
         });
+        it("Unsubscribing from signal dispatcher using one's return function.", function () {
+            var dispatcher = new strongly_typed_events_1.SignalDispatcher();
+            var resultNr = 0;
+            var unsub = dispatcher.one(function () {
+                resultNr += 2;
+            });
+            unsub();
+            dispatcher.dispatch();
+            chai_1.expect(resultNr, 'resultNr should be 0.').to.equal(0);
+        });
         it("Unsub from one subscription.", function () {
             var dispatcher = new strongly_typed_events_1.SignalDispatcher();
             var resultNr = 0;

--- a/test/signal-test.ts
+++ b/test/signal-test.ts
@@ -163,6 +163,20 @@ describe("Strongly Typed Events - Signal", function () {
             expect(resultNr, 'resultNr should be 0.').to.equal(0);
         });
 
+        it("Unsubscribing from signal dispatcher using one's return function.", function () {
+
+            let dispatcher = new SignalDispatcher();
+            let resultNr = 0;
+
+            let unsub = dispatcher.one(() => {
+                resultNr += 2;
+            });
+            unsub();
+            dispatcher.dispatch();
+
+            expect(resultNr, 'resultNr should be 0.').to.equal(0);
+        });
+
 
         it("Unsub from one subscription.", function () {
 

--- a/test/signal-test.ts
+++ b/test/signal-test.ts
@@ -118,6 +118,34 @@ describe("Strongly Typed Events - Signal", function () {
             expect(resultNr, 'resultNr should be 0.').to.equal(0);
         });
 
+        it("Unsubscribing from signal dispatcher using subscribe's return function.", function () {
+
+            let dispatcher = new SignalDispatcher();
+            let resultNr = 0;
+
+            let unsub = dispatcher.subscribe(() => {
+                resultNr += 2;
+            });
+            unsub();
+            dispatcher.dispatch();
+
+            expect(resultNr, 'resultNr should be 0.').to.equal(0);
+        });
+
+        it("Unsubscribing from signal dispatcher using sub's return function.", function () {
+
+            let dispatcher = new SignalDispatcher();
+            let resultNr = 0;
+
+            let unsub = dispatcher.sub(() => {
+                resultNr += 2;
+            });
+            unsub();
+            dispatcher.dispatch();
+
+            expect(resultNr, 'resultNr should be 0.').to.equal(0);
+        });
+
 
         it("Unsubscribing from one subscription.", function () {
 

--- a/test/simple-event-test.js
+++ b/test/simple-event-test.js
@@ -1,4 +1,5 @@
 'use strict';
+Object.defineProperty(exports, "__esModule", { value: true });
 var chai_1 = require("chai");
 var strongly_typed_events_1 = require("../strongly-typed-events");
 describe("Strongly Typed Events - Simple event", function () {
@@ -70,6 +71,26 @@ describe("Strongly Typed Events - Simple event", function () {
             };
             dispatcher.sub(fn);
             dispatcher.unsub(fn);
+            dispatcher.dispatch(6);
+            chai_1.expect(resultNr, 'resultNr should be 0.').to.equal(0);
+        });
+        it("Unsubscribing from simple event dispatcher using subscribe's return function.", function () {
+            var dispatcher = strongly_typed_events_1.default.createSimpleEventDispatcher();
+            var resultNr = 0;
+            var unsub = dispatcher.subscribe(function (nr) {
+                resultNr += nr;
+            });
+            unsub();
+            dispatcher.dispatch(6);
+            chai_1.expect(resultNr, 'resultNr should be 0.').to.equal(0);
+        });
+        it("Unsubscribing from simple event dispatcher using sub's return function.", function () {
+            var dispatcher = strongly_typed_events_1.default.createSimpleEventDispatcher();
+            var resultNr = 0;
+            var unsub = dispatcher.sub(function (nr) {
+                resultNr += nr;
+            });
+            unsub();
             dispatcher.dispatch(6);
             chai_1.expect(resultNr, 'resultNr should be 0.').to.equal(0);
         });

--- a/test/simple-event-test.js
+++ b/test/simple-event-test.js
@@ -105,6 +105,16 @@ describe("Strongly Typed Events - Simple event", function () {
             dispatcher.dispatch(6);
             chai_1.expect(resultNr, 'resultNr should be 0.').to.equal(0);
         });
+        it("Unsubscribing from simple event dispatcher using one's return function.", function () {
+            var dispatcher = strongly_typed_events_1.default.createSimpleEventDispatcher();
+            var resultNr = 0;
+            var unsub = dispatcher.one(function (nr) {
+                resultNr += nr;
+            });
+            unsub();
+            dispatcher.dispatch(6);
+            chai_1.expect(resultNr, 'resultNr should be 0.').to.equal(0);
+        });
         it("Unsub from one subscription.", function () {
             var dispatcher = strongly_typed_events_1.default.createSimpleEventDispatcher();
             var resultNr = 0;

--- a/test/simple-event-test.ts
+++ b/test/simple-event-test.ts
@@ -115,6 +115,34 @@ describe("Strongly Typed Events - Simple event", function () {
             expect(resultNr, 'resultNr should be 0.').to.equal(0);
         });
 
+        it("Unsubscribing from simple event dispatcher using subscribe's return function.", function () {
+
+            let dispatcher = _e.createSimpleEventDispatcher<number>();
+            let resultNr = 0;
+
+            let unsub = dispatcher.subscribe((nr: number) => {
+                resultNr += nr;
+            });
+            unsub();
+            dispatcher.dispatch(6);
+
+            expect(resultNr, 'resultNr should be 0.').to.equal(0);
+        });
+
+        it("Unsubscribing from simple event dispatcher using sub's return function.", function () {
+
+            let dispatcher = _e.createSimpleEventDispatcher<number>();
+            let resultNr = 0;
+
+            let unsub = dispatcher.sub((nr: number) => {
+                resultNr += nr;
+            });
+            unsub();
+            dispatcher.dispatch(6);
+
+            expect(resultNr, 'resultNr should be 0.').to.equal(0);
+        });
+
 
         it("Unsubscribing to a one subscription.", function () {
 

--- a/test/simple-event-test.ts
+++ b/test/simple-event-test.ts
@@ -160,6 +160,20 @@ describe("Strongly Typed Events - Simple event", function () {
             expect(resultNr, 'resultNr should be 0.').to.equal(0);
         });
 
+        it("Unsubscribing from simple event dispatcher using one's return function.", function () {
+
+            let dispatcher = _e.createSimpleEventDispatcher<number>();
+            let resultNr = 0;
+
+            let unsub = dispatcher.one((nr: number) => {
+                resultNr += nr;
+            });
+            unsub();
+            dispatcher.dispatch(6);
+
+            expect(resultNr, 'resultNr should be 0.').to.equal(0);
+        });
+
         it("Unsub from one subscription.", function () {
 
             let dispatcher = _e.createSimpleEventDispatcher<number>();


### PR DESCRIPTION
```
let unsubscribe = myObject.onMyEvent.subscribe((s: MyClass, a: string) => {
    alert(s);
});
unsubscribe();
```

I added unsubscription callback functions to ISubscribable's _subscribe_, _sub_ and _one_ methods, to allow for a different unsubscription syntax that I find easier to use in some cases (if you want to unsubscribe from inside the event handler function for instance).

Other than using _unsubscibe_, unsubscribing using the returned function doesn't require one to assign their event handler to a variable and the event property has to be referenced only once.