### PR TITLE
Markdown Syntax Highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This project gives you the following event types:
 
 ### Subscription made easy
 An example says more than a 1000 words. Imagine if you have events like this on your class:
-```
+```typescript
 let clock = new Clock("Smu", 1000);
 
 //log the ticks to the console - this is a signal event
@@ -31,7 +31,7 @@ clock.onClockTick.subscribe((c, n) =>
 ### Events made easy
 So let's look at the implementation from a TypeScript perspective. (Do you program NodeJs without typescript? <a href="documentation/HowToUseInNodeJs.md">Check this</a>.)
 
-```
+```typescript
 import { SignalDispatcher, SimpleEventDispatcher, EventDispatcher } from "strongly-typed-events";
 
 class Clock {

--- a/documentation/HowToAddAnEventToAClass.md
+++ b/documentation/HowToAddAnEventToAClass.md
@@ -6,7 +6,7 @@ Adding an event to a class is pretty easy. Expose it an an `IEvent<TSender, TArg
 ### Example
 Conside the following example:
 
-```
+```typescript
 class MyClass
 {
 	private _myEvent = new EventDispatcher<MyClass, string>();
@@ -30,7 +30,7 @@ or class the `asEvent()` on the dispatcher to return a wrapper with the dispatch
 
 ### Usage
 Subscibing to an event is pretty straight forward:
-```
+```typescript
 let myObject = new MyClass();
 myObject.onMyEvent.subscribe((s: MyClass, a: string) => {
 	alert(s);
@@ -39,7 +39,7 @@ myObject.onMyEvent.subscribe((s: MyClass, a: string) => {
 
 An event handler can be unsubscribed like this:
 
-```
+```typescript
 let unsubscribe = myObject.onMyEvent.subscribe((s: MyClass, a: string) => {
 	alert(s);
 });

--- a/documentation/HowToAddAnEventToAnInterface.md
+++ b/documentation/HowToAddAnEventToAnInterface.md
@@ -4,7 +4,7 @@ interfaces don't support 'getter' properies. The best way to implement them is w
 
 ### Example
 
-````
+````typescript
 interface IMyInterface
 {
 	onMyEvent(): IEvent<IMyInterface, IMyArgument>;
@@ -26,7 +26,7 @@ interface IMyArgument
 ````
 
 ### Usage
-````
+````typescript
 let myObject: IMyInterface = new MyClass();
 myObject.onMyEvent().subscribe((s: IMyInterface, a: IMyArgument) => {
 	alert('Ping!');

--- a/documentation/HowToAddDynamicNamedEeventsToAClass.md
+++ b/documentation/HowToAddDynamicNamedEeventsToAClass.md
@@ -4,7 +4,7 @@ Need to add named event support to your class? Implement the `IEventHandling<TSe
 `ISimpleEventHandling<TArgs>` interface or extend from the abstract `EventHandlingBase` or `SimpleEventHandling` class. 
 
 ### Example
-```
+```typescript
 class DynamicEventsExample implements IEventHandling<DynamicEventsExample, DynamicEventsExampleArgs>
 {
     private _events = new EventList<DynamicEventsExample, DynamicEventsExampleArgs>();

--- a/documentation/HowToAddMultipleEventsToAClass.md
+++ b/documentation/HowToAddMultipleEventsToAClass.md
@@ -9,7 +9,7 @@ start, pause, reset. The events will be implemented using an `EventList<Stopwach
 a `get` method to get the event dispatcher by name. When it doesn't exists, one will be created an returned. The dispatch is 
 done by calling the `dispatch` on the dispatcher.
 
-```
+```typescript
 class Stopwatch {
 
     private _events = new EventList<Stopwatch, StopwatchEventArgs>();

--- a/documentation/HowToDoAsynchronousEventDispatching.md
+++ b/documentation/HowToDoAsynchronousEventDispatching.md
@@ -6,7 +6,7 @@ handlers from being executed. That's why dispatchers can dispatch asynchronously
 ### Example
 Conside the following example:
 
-```
+```typescript
 QUnit.test('Testing simple event async dispatch', (assert) => {
 
     let dispatcher = new SimpleEventDispatcher<number>();

--- a/documentation/HowToUseInNodeJs.md
+++ b/documentation/HowToUseInNodeJs.md
@@ -5,7 +5,7 @@ npm install strongly-typed-events --save
 ```
 ## Code example
 Using it is pretty straight forward:
-```
+```typescript
 const { EventDispatcher } = require('strongly-typed-events');
 
 export class TfsBuildClient {
@@ -20,7 +20,7 @@ export class TfsBuildClient {
 ## Exposed classes and methods
 The following classes are exposed through the module exports:
 
-```
+```typescript
     EventDispatcher: <TSender, TArgs>() => EventDispatcher<TSender, TArgs>;
     SimpleEventDispatcher: <TArgs>() => SimpleEventDispatcher<TArgs>;
     SignalDispatcher: () => SignalDispatcher;


### PR DESCRIPTION
Added `typescript` to all the fenced code blocks in your markdown to enable syntax highlighting.