### PR TITLE
Use webpack to generate UMD bundles

### DIFF
--- a/packages/ste-browser/package-lock.json
+++ b/packages/ste-browser/package-lock.json
@@ -1,9 +1,15 @@
 {
 	"name": "ste-browser",
-	"version": "1.3.4",
+	"version": "1.3.11",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@sindresorhus/is": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
+			"integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==",
+			"dev": true
+		},
 		"@types/node": {
 			"version": "9.4.7",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.7.tgz",
@@ -26,6 +32,23 @@
 			"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
 			"dev": true
 		},
+		"acorn-dynamic-import": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz",
+			"integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
+			"dev": true,
+			"requires": {
+				"acorn": "5.5.3"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "5.5.3",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+					"integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
+					"dev": true
+				}
+			}
+		},
 		"acorn-node": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.3.0.tgz",
@@ -44,6 +67,24 @@
 				}
 			}
 		},
+		"ajv": {
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.4.0.tgz",
+			"integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
+			"dev": true,
+			"requires": {
+				"fast-deep-equal": "1.1.0",
+				"fast-json-stable-stringify": "2.0.0",
+				"json-schema-traverse": "0.3.1",
+				"uri-js": "3.0.2"
+			}
+		},
+		"ajv-keywords": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.1.0.tgz",
+			"integrity": "sha1-rCsnk5xUPpXSwG5/f1wnvkqlQ74=",
+			"dev": true
+		},
 		"ansi-align": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
@@ -52,6 +93,12 @@
 			"requires": {
 				"string-width": "2.1.1"
 			}
+		},
+		"ansi-escapes": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+			"integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+			"dev": true
 		},
 		"ansi-regex": {
 			"version": "3.0.0",
@@ -67,6 +114,52 @@
 			"requires": {
 				"color-convert": "1.9.1"
 			}
+		},
+		"any-observable": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.2.0.tgz",
+			"integrity": "sha1-xnhwBYADV5AJCD9UrAq6+1wz0kI=",
+			"dev": true
+		},
+		"anymatch": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+			"dev": true,
+			"requires": {
+				"micromatch": "3.1.10",
+				"normalize-path": "2.1.1"
+			}
+		},
+		"aproba": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+			"dev": true
+		},
+		"arr-diff": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+			"dev": true
+		},
+		"arr-flatten": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+			"dev": true
+		},
+		"arr-union": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+			"dev": true
+		},
+		"array-differ": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+			"integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+			"dev": true
 		},
 		"array-filter": {
 			"version": "0.0.1",
@@ -107,6 +200,18 @@
 			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
 			"dev": true
 		},
+		"array-unique": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+			"dev": true
+		},
+		"arrify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+			"dev": true
+		},
 		"asn1.js": {
 			"version": "4.10.1",
 			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
@@ -127,6 +232,18 @@
 				"util": "0.10.3"
 			}
 		},
+		"assign-symbols": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+			"dev": true
+		},
+		"ast-types": {
+			"version": "0.11.3",
+			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.11.3.tgz",
+			"integrity": "sha512-XA5o5dsNw8MhyW0Q7MWXJWc4oOzZKbdsEJq45h7c8q/d9DwWZ5F2ugUc1PuMLPGsUnphCt/cNDHu8JeBbxf1qA==",
+			"dev": true
+		},
 		"astw": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/astw/-/astw-2.2.0.tgz",
@@ -136,16 +253,967 @@
 				"acorn": "4.0.13"
 			}
 		},
+		"async": {
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+			"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+			"dev": true
+		},
+		"async-each": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+			"dev": true
+		},
+		"atob": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/atob/-/atob-2.0.3.tgz",
+			"integrity": "sha1-GcenYEc3dEaPILLS0DNyrX1Mv10=",
+			"dev": true
+		},
+		"babel-code-frame": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+			"dev": true,
+			"requires": {
+				"chalk": "1.1.3",
+				"esutils": "2.0.2",
+				"js-tokens": "3.0.2"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "2.2.1",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "2.0.0",
+						"strip-ansi": "3.0.1",
+						"supports-color": "2.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+					"dev": true
+				}
+			}
+		},
+		"babel-core": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
+			"integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+			"dev": true,
+			"requires": {
+				"babel-code-frame": "6.26.0",
+				"babel-generator": "6.26.1",
+				"babel-helpers": "6.24.1",
+				"babel-messages": "6.23.0",
+				"babel-register": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"convert-source-map": "1.5.1",
+				"debug": "2.6.9",
+				"json5": "0.5.1",
+				"lodash": "4.17.5",
+				"minimatch": "3.0.4",
+				"path-is-absolute": "1.0.1",
+				"private": "0.1.8",
+				"slash": "1.0.0",
+				"source-map": "0.5.7"
+			},
+			"dependencies": {
+				"babylon": {
+					"version": "6.18.0",
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+					"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+					"dev": true
+				},
+				"convert-source-map": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+					"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
+			}
+		},
+		"babel-generator": {
+			"version": "6.26.1",
+			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+			"dev": true,
+			"requires": {
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"detect-indent": "4.0.0",
+				"jsesc": "1.3.0",
+				"lodash": "4.17.5",
+				"source-map": "0.5.7",
+				"trim-right": "1.0.1"
+			},
+			"dependencies": {
+				"jsesc": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+					"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
+			}
+		},
+		"babel-helper-bindify-decorators": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz",
+			"integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-helper-builder-binary-assignment-operator-visitor": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
+			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+			"dev": true,
+			"requires": {
+				"babel-helper-explode-assignable-expression": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-helper-call-delegate": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+			"dev": true,
+			"requires": {
+				"babel-helper-hoist-variables": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-helper-define-map": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
+			"integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
+			"dev": true,
+			"requires": {
+				"babel-helper-function-name": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"lodash": "4.17.5"
+			}
+		},
+		"babel-helper-explode-assignable-expression": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
+			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-helper-explode-class": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz",
+			"integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
+			"dev": true,
+			"requires": {
+				"babel-helper-bindify-decorators": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-helper-function-name": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+			"dev": true,
+			"requires": {
+				"babel-helper-get-function-arity": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-helper-get-function-arity": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-helper-hoist-variables": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-helper-optimise-call-expression": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+			"integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-helper-regex": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
+			"integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"lodash": "4.17.5"
+			}
+		},
+		"babel-helper-remap-async-to-generator": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
+			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+			"dev": true,
+			"requires": {
+				"babel-helper-function-name": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-helper-replace-supers": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+			"integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+			"dev": true,
+			"requires": {
+				"babel-helper-optimise-call-expression": "6.24.1",
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-helpers": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
+			}
+		},
+		"babel-messages": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-check-es2015-constants": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-syntax-async-functions": {
+			"version": "6.13.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
+			"dev": true
+		},
+		"babel-plugin-syntax-async-generators": {
+			"version": "6.13.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
+			"integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o=",
+			"dev": true
+		},
+		"babel-plugin-syntax-class-constructor-call": {
+			"version": "6.18.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-constructor-call/-/babel-plugin-syntax-class-constructor-call-6.18.0.tgz",
+			"integrity": "sha1-nLnTn+Q8hgC+yBRkVt3L1OGnZBY=",
+			"dev": true
+		},
+		"babel-plugin-syntax-class-properties": {
+			"version": "6.13.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
+			"integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94=",
+			"dev": true
+		},
+		"babel-plugin-syntax-decorators": {
+			"version": "6.13.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz",
+			"integrity": "sha1-MSVjtNvePMgGzuPkFszurd0RrAs=",
+			"dev": true
+		},
+		"babel-plugin-syntax-dynamic-import": {
+			"version": "6.18.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
+			"integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=",
+			"dev": true
+		},
+		"babel-plugin-syntax-exponentiation-operator": {
+			"version": "6.13.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
+			"dev": true
+		},
+		"babel-plugin-syntax-export-extensions": {
+			"version": "6.13.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.13.0.tgz",
+			"integrity": "sha1-cKFITw+QiaToStRLrDU8lbmxJyE=",
+			"dev": true
+		},
+		"babel-plugin-syntax-flow": {
+			"version": "6.18.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
+			"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0=",
+			"dev": true
+		},
+		"babel-plugin-syntax-object-rest-spread": {
+			"version": "6.13.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
+			"dev": true
+		},
+		"babel-plugin-syntax-trailing-function-commas": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
+			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
+			"dev": true
+		},
+		"babel-plugin-transform-async-generator-functions": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
+			"integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
+			"dev": true,
+			"requires": {
+				"babel-helper-remap-async-to-generator": "6.24.1",
+				"babel-plugin-syntax-async-generators": "6.13.0",
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-async-to-generator": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
+			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+			"dev": true,
+			"requires": {
+				"babel-helper-remap-async-to-generator": "6.24.1",
+				"babel-plugin-syntax-async-functions": "6.13.0",
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-class-constructor-call": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.24.1.tgz",
+			"integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk=",
+			"dev": true,
+			"requires": {
+				"babel-plugin-syntax-class-constructor-call": "6.18.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-class-properties": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
+			"integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
+			"dev": true,
+			"requires": {
+				"babel-helper-function-name": "6.24.1",
+				"babel-plugin-syntax-class-properties": "6.13.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-decorators": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz",
+			"integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
+			"dev": true,
+			"requires": {
+				"babel-helper-explode-class": "6.24.1",
+				"babel-plugin-syntax-decorators": "6.13.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-arrow-functions": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+			"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-block-scoped-functions": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+			"integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-block-scoping": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
+			"integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"lodash": "4.17.5"
+			}
+		},
+		"babel-plugin-transform-es2015-classes": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+			"integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+			"dev": true,
+			"requires": {
+				"babel-helper-define-map": "6.26.0",
+				"babel-helper-function-name": "6.24.1",
+				"babel-helper-optimise-call-expression": "6.24.1",
+				"babel-helper-replace-supers": "6.24.1",
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-computed-properties": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+			"integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-destructuring": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-duplicate-keys": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+			"integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-for-of": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+			"integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-function-name": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+			"dev": true,
+			"requires": {
+				"babel-helper-function-name": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-literals": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+			"integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-modules-amd": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+			"integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
+			"dev": true,
+			"requires": {
+				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-modules-commonjs": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
+			"integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
+			"dev": true,
+			"requires": {
+				"babel-plugin-transform-strict-mode": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-modules-systemjs": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+			"integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
+			"dev": true,
+			"requires": {
+				"babel-helper-hoist-variables": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-modules-umd": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+			"integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
+			"dev": true,
+			"requires": {
+				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-object-super": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+			"integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+			"dev": true,
+			"requires": {
+				"babel-helper-replace-supers": "6.24.1",
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-parameters": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+			"dev": true,
+			"requires": {
+				"babel-helper-call-delegate": "6.24.1",
+				"babel-helper-get-function-arity": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-shorthand-properties": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+			"integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-spread": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-sticky-regex": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+			"dev": true,
+			"requires": {
+				"babel-helper-regex": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-template-literals": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+			"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-typeof-symbol": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+			"integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-unicode-regex": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+			"dev": true,
+			"requires": {
+				"babel-helper-regex": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"regexpu-core": "2.0.0"
+			}
+		},
+		"babel-plugin-transform-exponentiation-operator": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
+			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+			"dev": true,
+			"requires": {
+				"babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+				"babel-plugin-syntax-exponentiation-operator": "6.13.0",
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-export-extensions": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.22.0.tgz",
+			"integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
+			"dev": true,
+			"requires": {
+				"babel-plugin-syntax-export-extensions": "6.13.0",
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-flow-strip-types": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
+			"integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
+			"dev": true,
+			"requires": {
+				"babel-plugin-syntax-flow": "6.18.0",
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-object-rest-spread": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
+			"integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
+			"dev": true,
+			"requires": {
+				"babel-plugin-syntax-object-rest-spread": "6.13.0",
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-regenerator": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
+			"integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
+			"dev": true,
+			"requires": {
+				"regenerator-transform": "0.10.1"
+			}
+		},
+		"babel-plugin-transform-strict-mode": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-preset-es2015": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
+			"integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
+			"dev": true,
+			"requires": {
+				"babel-plugin-check-es2015-constants": "6.22.0",
+				"babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+				"babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+				"babel-plugin-transform-es2015-block-scoping": "6.26.0",
+				"babel-plugin-transform-es2015-classes": "6.24.1",
+				"babel-plugin-transform-es2015-computed-properties": "6.24.1",
+				"babel-plugin-transform-es2015-destructuring": "6.23.0",
+				"babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+				"babel-plugin-transform-es2015-for-of": "6.23.0",
+				"babel-plugin-transform-es2015-function-name": "6.24.1",
+				"babel-plugin-transform-es2015-literals": "6.22.0",
+				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
+				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+				"babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+				"babel-plugin-transform-es2015-modules-umd": "6.24.1",
+				"babel-plugin-transform-es2015-object-super": "6.24.1",
+				"babel-plugin-transform-es2015-parameters": "6.24.1",
+				"babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+				"babel-plugin-transform-es2015-spread": "6.22.0",
+				"babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+				"babel-plugin-transform-es2015-template-literals": "6.22.0",
+				"babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+				"babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+				"babel-plugin-transform-regenerator": "6.26.0"
+			}
+		},
+		"babel-preset-stage-1": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-preset-stage-1/-/babel-preset-stage-1-6.24.1.tgz",
+			"integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A=",
+			"dev": true,
+			"requires": {
+				"babel-plugin-transform-class-constructor-call": "6.24.1",
+				"babel-plugin-transform-export-extensions": "6.22.0",
+				"babel-preset-stage-2": "6.24.1"
+			}
+		},
+		"babel-preset-stage-2": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz",
+			"integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
+			"dev": true,
+			"requires": {
+				"babel-plugin-syntax-dynamic-import": "6.18.0",
+				"babel-plugin-transform-class-properties": "6.24.1",
+				"babel-plugin-transform-decorators": "6.24.1",
+				"babel-preset-stage-3": "6.24.1"
+			}
+		},
+		"babel-preset-stage-3": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz",
+			"integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
+			"dev": true,
+			"requires": {
+				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
+				"babel-plugin-transform-async-generator-functions": "6.24.1",
+				"babel-plugin-transform-async-to-generator": "6.24.1",
+				"babel-plugin-transform-exponentiation-operator": "6.24.1",
+				"babel-plugin-transform-object-rest-spread": "6.26.0"
+			}
+		},
+		"babel-register": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+			"dev": true,
+			"requires": {
+				"babel-core": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"core-js": "2.5.3",
+				"home-or-tmp": "2.0.0",
+				"lodash": "4.17.5",
+				"mkdirp": "0.5.1",
+				"source-map-support": "0.4.18"
+			}
+		},
+		"babel-runtime": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+			"dev": true,
+			"requires": {
+				"core-js": "2.5.3",
+				"regenerator-runtime": "0.11.1"
+			}
+		},
+		"babel-template": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"lodash": "4.17.5"
+			},
+			"dependencies": {
+				"babylon": {
+					"version": "6.18.0",
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+					"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+					"dev": true
+				}
+			}
+		},
+		"babel-traverse": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+			"dev": true,
+			"requires": {
+				"babel-code-frame": "6.26.0",
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"debug": "2.6.9",
+				"globals": "9.18.0",
+				"invariant": "2.2.4",
+				"lodash": "4.17.5"
+			},
+			"dependencies": {
+				"babylon": {
+					"version": "6.18.0",
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+					"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+					"dev": true
+				}
+			}
+		},
+		"babel-types": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"esutils": "2.0.2",
+				"lodash": "4.17.5",
+				"to-fast-properties": "1.0.3"
+			}
+		},
+		"babylon": {
+			"version": "7.0.0-beta.42",
+			"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.42.tgz",
+			"integrity": "sha512-h6E/OkkvcBw/JimbL0p8dIaxrcuQn3QmIYGC/GtJlRYif5LTKBYPHXYwqluJpfS/kOXoz0go+9mkmOVC0M+zWw==",
+			"dev": true
+		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 			"dev": true
 		},
+		"base": {
+			"version": "0.11.2",
+			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+			"dev": true,
+			"requires": {
+				"cache-base": "1.0.1",
+				"class-utils": "0.3.6",
+				"component-emitter": "1.2.1",
+				"define-property": "1.0.0",
+				"isobject": "3.0.1",
+				"mixin-deep": "1.3.1",
+				"pascalcase": "0.1.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "1.0.2"
+					}
+				}
+			}
+		},
 		"base64-js": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.3.tgz",
 			"integrity": "sha512-MsAhsUW1GxCdgYSO6tAfZrNapmUKk7mWx/k5mFY/A1gBtkaCaNapTg+FExCw1r9yeaZhqx/xPg43xgTFH6KL5w==",
+			"dev": true
+		},
+		"big.js": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
+			"integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
+			"dev": true
+		},
+		"binary-extensions": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
+			"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
+			"dev": true
+		},
+		"binaryextensions": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.1.1.tgz",
+			"integrity": "sha512-XBaoWE9RW8pPdPQNibZsW2zh8TW6gcarXp1FZPwT8Uop8ScSNldJEWf2k9l3HeTqdrEwsOsFcq74RiJECW34yA==",
+			"dev": true
+		},
+		"bluebird": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+			"integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
 			"dev": true
 		},
 		"bn.js": {
@@ -185,6 +1253,46 @@
 			"requires": {
 				"balanced-match": "1.0.0",
 				"concat-map": "0.0.1"
+			}
+		},
+		"braces": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.1.tgz",
+			"integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
+			"dev": true,
+			"requires": {
+				"arr-flatten": "1.1.0",
+				"array-unique": "0.3.2",
+				"define-property": "1.0.0",
+				"extend-shallow": "2.0.1",
+				"fill-range": "4.0.0",
+				"isobject": "3.0.1",
+				"kind-of": "6.0.2",
+				"repeat-element": "1.1.2",
+				"snapdragon": "0.8.2",
+				"snapdragon-node": "2.1.1",
+				"split-string": "3.1.0",
+				"to-regex": "3.0.2"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "1.0.2"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "0.1.1"
+					}
+				}
 			}
 		},
 		"brorand": {
@@ -378,6 +1486,59 @@
 			"integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
 			"dev": true
 		},
+		"cacache": {
+			"version": "10.0.4",
+			"resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
+			"integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
+			"dev": true,
+			"requires": {
+				"bluebird": "3.5.1",
+				"chownr": "1.0.1",
+				"glob": "7.1.2",
+				"graceful-fs": "4.1.11",
+				"lru-cache": "4.1.2",
+				"mississippi": "2.0.0",
+				"mkdirp": "0.5.1",
+				"move-concurrently": "1.0.1",
+				"promise-inflight": "1.0.1",
+				"rimraf": "2.6.2",
+				"ssri": "5.3.0",
+				"unique-filename": "1.1.0",
+				"y18n": "4.0.0"
+			}
+		},
+		"cache-base": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+			"dev": true,
+			"requires": {
+				"collection-visit": "1.0.0",
+				"component-emitter": "1.2.1",
+				"get-value": "2.0.6",
+				"has-value": "1.0.0",
+				"isobject": "3.0.1",
+				"set-value": "2.0.0",
+				"to-object-path": "0.3.0",
+				"union-value": "1.0.0",
+				"unset-value": "1.0.0"
+			}
+		},
+		"cacheable-request": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.4.tgz",
+			"integrity": "sha1-DYCIAbY0KtM8kd+dC0TcCbkeXD0=",
+			"dev": true,
+			"requires": {
+				"clone-response": "1.0.2",
+				"get-stream": "3.0.0",
+				"http-cache-semantics": "3.8.1",
+				"keyv": "3.0.0",
+				"lowercase-keys": "1.0.0",
+				"normalize-url": "2.0.1",
+				"responselike": "1.0.2"
+			}
+		},
 		"cached-path-relative": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.1.tgz",
@@ -417,6 +1578,44 @@
 				"supports-color": "5.3.0"
 			}
 		},
+		"chardet": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+			"dev": true
+		},
+		"chokidar": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.3.tgz",
+			"integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
+			"dev": true,
+			"requires": {
+				"anymatch": "2.0.0",
+				"async-each": "1.0.1",
+				"braces": "2.3.1",
+				"fsevents": "1.1.3",
+				"glob-parent": "3.1.0",
+				"inherits": "2.0.3",
+				"is-binary-path": "1.0.1",
+				"is-glob": "4.0.0",
+				"normalize-path": "2.1.1",
+				"path-is-absolute": "1.0.1",
+				"readdirp": "2.1.0",
+				"upath": "1.0.4"
+			}
+		},
+		"chownr": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+			"integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
+			"dev": true
+		},
+		"chrome-trace-event": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-0.1.2.tgz",
+			"integrity": "sha1-kPNohdU0WlBiEzLwcXtZWIPV2YI=",
+			"dev": true
+		},
 		"cipher-base": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
@@ -427,11 +1626,241 @@
 				"safe-buffer": "5.1.1"
 			}
 		},
+		"class-utils": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+			"dev": true,
+			"requires": {
+				"arr-union": "3.1.0",
+				"define-property": "0.2.5",
+				"isobject": "3.0.1",
+				"static-extend": "0.1.2"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "0.1.6"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"dev": true,
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"dev": true,
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "0.1.6",
+						"is-data-descriptor": "0.1.4",
+						"kind-of": "5.1.0"
+					}
+				},
+				"kind-of": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+					"dev": true
+				}
+			}
+		},
 		"cli-boxes": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
 			"integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
 			"dev": true
+		},
+		"cli-cursor": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+			"dev": true,
+			"requires": {
+				"restore-cursor": "2.0.0"
+			}
+		},
+		"cli-spinners": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.1.2.tgz",
+			"integrity": "sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw=",
+			"dev": true
+		},
+		"cli-table": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
+			"integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
+			"dev": true,
+			"requires": {
+				"colors": "1.0.3"
+			},
+			"dependencies": {
+				"colors": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+					"integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+					"dev": true
+				}
+			}
+		},
+		"cli-truncate": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
+			"integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
+			"dev": true,
+			"requires": {
+				"slice-ansi": "0.0.4",
+				"string-width": "1.0.2"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"dev": true,
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"dev": true,
+					"requires": {
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				}
+			}
+		},
+		"cli-width": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+			"dev": true
+		},
+		"cliui": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
+			"integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
+			"dev": true,
+			"requires": {
+				"string-width": "2.1.1",
+				"strip-ansi": "4.0.0",
+				"wrap-ansi": "2.1.0"
+			}
+		},
+		"clone": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+			"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+			"dev": true
+		},
+		"clone-buffer": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+			"integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
+			"dev": true
+		},
+		"clone-response": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+			"integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+			"dev": true,
+			"requires": {
+				"mimic-response": "1.0.0"
+			}
+		},
+		"clone-stats": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+			"integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
+			"dev": true
+		},
+		"cloneable-readable": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
+			"integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
+			"dev": true,
+			"requires": {
+				"inherits": "2.0.3",
+				"process-nextick-args": "2.0.0",
+				"readable-stream": "2.3.5"
+			}
+		},
+		"code-point-at": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+			"dev": true
+		},
+		"collection-visit": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+			"dev": true,
+			"requires": {
+				"map-visit": "1.0.0",
+				"object-visit": "1.0.1"
+			}
 		},
 		"color-convert": {
 			"version": "1.9.1",
@@ -446,6 +1875,12 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
+		},
+		"colors": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/colors/-/colors-1.2.1.tgz",
+			"integrity": "sha512-s8+wktIuDSLffCywiwSxQOMqtPxML11a/dtHE17tMn4B1MSWw/C22EKf7M2KGUBcDaVFEGT+S8N02geDXeuNKg==",
 			"dev": true
 		},
 		"combine-source-map": {
@@ -467,6 +1902,24 @@
 					"dev": true
 				}
 			}
+		},
+		"commander": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+			"integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
+			"dev": true
+		},
+		"commondir": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+			"dev": true
+		},
+		"component-emitter": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+			"dev": true
 		},
 		"concat-map": {
 			"version": "0.0.1",
@@ -518,6 +1971,32 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
 			"integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
+			"dev": true
+		},
+		"copy-concurrently": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+			"integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
+			"dev": true,
+			"requires": {
+				"aproba": "1.2.0",
+				"fs-write-stream-atomic": "1.0.10",
+				"iferr": "0.1.5",
+				"mkdirp": "0.5.1",
+				"rimraf": "2.6.2",
+				"run-queue": "1.0.3"
+			}
+		},
+		"copy-descriptor": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+			"dev": true
+		},
+		"core-js": {
+			"version": "2.5.3",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+			"integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
 			"dev": true
 		},
 		"core-util-is": {
@@ -616,11 +2095,44 @@
 				"array-find-index": "1.0.2"
 			}
 		},
+		"cyclist": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
+			"integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
+			"dev": true
+		},
+		"dargs": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/dargs/-/dargs-5.1.0.tgz",
+			"integrity": "sha1-7H6lDHhWTNNsnV7Bj2Yyn63ieCk=",
+			"dev": true
+		},
+		"date-fns": {
+			"version": "1.29.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
+			"integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==",
+			"dev": true
+		},
 		"date-now": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
 			"integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
 			"dev": true
+		},
+		"dateformat": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+			"integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
+			"dev": true
+		},
+		"debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"requires": {
+				"ms": "2.0.0"
+			}
 		},
 		"decamelize": {
 			"version": "1.2.0",
@@ -628,11 +2140,36 @@
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
 			"dev": true
 		},
+		"decode-uri-component": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+			"dev": true
+		},
+		"decompress-response": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+			"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+			"dev": true,
+			"requires": {
+				"mimic-response": "1.0.0"
+			}
+		},
 		"deep-extend": {
 			"version": "0.4.2",
 			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
 			"integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
 			"dev": true
+		},
+		"define-property": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+			"dev": true,
+			"requires": {
+				"is-descriptor": "1.0.2",
+				"isobject": "3.0.1"
+			}
 		},
 		"defined": {
 			"version": "1.0.0",
@@ -687,6 +2224,21 @@
 				"minimalistic-assert": "1.0.0"
 			}
 		},
+		"detect-conflict": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/detect-conflict/-/detect-conflict-1.0.1.tgz",
+			"integrity": "sha1-CIZXpmqWHAUBnbfEIwiDsca0F24=",
+			"dev": true
+		},
+		"detect-indent": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+			"dev": true,
+			"requires": {
+				"repeating": "2.0.1"
+			}
+		},
 		"detective": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/detective/-/detective-5.1.0.tgz",
@@ -697,6 +2249,12 @@
 				"defined": "1.0.0",
 				"minimist": "1.2.0"
 			}
+		},
+		"diff": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+			"dev": true
 		},
 		"diffie-hellman": {
 			"version": "5.0.2",
@@ -739,6 +2297,36 @@
 			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
 			"dev": true
 		},
+		"duplexify": {
+			"version": "3.5.4",
+			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.4.tgz",
+			"integrity": "sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==",
+			"dev": true,
+			"requires": {
+				"end-of-stream": "1.4.1",
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.5",
+				"stream-shift": "1.0.0"
+			}
+		},
+		"editions": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
+			"integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg==",
+			"dev": true
+		},
+		"ejs": {
+			"version": "2.5.8",
+			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.8.tgz",
+			"integrity": "sha512-QIDZL54fyV8MDcAsO91BMH1ft2qGGaHIJsJIA/+t+7uvXol1dm413fPcUgUb4k8F/9457rx4/KFE4XfDifrQxQ==",
+			"dev": true
+		},
+		"elegant-spinner": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+			"integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
+			"dev": true
+		},
 		"elliptic": {
 			"version": "6.4.0",
 			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
@@ -754,6 +2342,51 @@
 				"minimalistic-crypto-utils": "1.0.1"
 			}
 		},
+		"emojis-list": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
+			"dev": true
+		},
+		"end-of-stream": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"dev": true,
+			"requires": {
+				"once": "1.4.0"
+			}
+		},
+		"enhanced-resolve": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.0.0.tgz",
+			"integrity": "sha512-jox/62b2GofV1qTUQTMPEJSDIGycS43evqYzD/KVtEb9OCoki9cnacUPxCrZa7JfPzZSYOCZhu9O9luaMxAX8g==",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"memory-fs": "0.4.1",
+				"tapable": "1.0.0"
+			}
+		},
+		"errno": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+			"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+			"dev": true,
+			"requires": {
+				"prr": "1.0.1"
+			}
+		},
+		"error": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/error/-/error-7.0.2.tgz",
+			"integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
+			"dev": true,
+			"requires": {
+				"string-template": "0.2.1",
+				"xtend": "4.0.1"
+			}
+		},
 		"error-ex": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
@@ -767,6 +2400,43 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
+		},
+		"eslint-scope": {
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+			"integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+			"dev": true,
+			"requires": {
+				"esrecurse": "4.2.1",
+				"estraverse": "4.2.0"
+			}
+		},
+		"esprima": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+			"dev": true
+		},
+		"esrecurse": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+			"dev": true,
+			"requires": {
+				"estraverse": "4.2.0"
+			}
+		},
+		"estraverse": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+			"dev": true
+		},
+		"esutils": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
 			"dev": true
 		},
 		"events": {
@@ -800,6 +2470,293 @@
 				"strip-eof": "1.0.0"
 			}
 		},
+		"exit-hook": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+			"integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+			"dev": true
+		},
+		"expand-brackets": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+			"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+			"dev": true,
+			"requires": {
+				"debug": "2.6.9",
+				"define-property": "0.2.5",
+				"extend-shallow": "2.0.1",
+				"posix-character-classes": "0.1.1",
+				"regex-not": "1.0.2",
+				"snapdragon": "0.8.2",
+				"to-regex": "3.0.2"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "0.1.6"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "0.1.1"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"dev": true,
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"dev": true,
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "0.1.6",
+						"is-data-descriptor": "0.1.4",
+						"kind-of": "5.1.0"
+					}
+				},
+				"kind-of": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+					"dev": true
+				}
+			}
+		},
+		"expand-range": {
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+			"dev": true,
+			"requires": {
+				"fill-range": "2.2.3"
+			},
+			"dependencies": {
+				"fill-range": {
+					"version": "2.2.3",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+					"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+					"dev": true,
+					"requires": {
+						"is-number": "2.1.0",
+						"isobject": "2.1.0",
+						"randomatic": "1.1.7",
+						"repeat-element": "1.1.2",
+						"repeat-string": "1.6.1"
+					}
+				},
+				"is-number": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+					"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+					"dev": true,
+					"requires": {
+						"kind-of": "3.2.2"
+					}
+				},
+				"isobject": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+					"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+					"dev": true,
+					"requires": {
+						"isarray": "1.0.0"
+					}
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "1.1.6"
+					}
+				}
+			}
+		},
+		"expand-tilde": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+			"integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+			"dev": true,
+			"requires": {
+				"homedir-polyfill": "1.0.1"
+			}
+		},
+		"extend-shallow": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+			"dev": true,
+			"requires": {
+				"assign-symbols": "1.0.0",
+				"is-extendable": "1.0.1"
+			},
+			"dependencies": {
+				"is-extendable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"dev": true,
+					"requires": {
+						"is-plain-object": "2.0.4"
+					}
+				}
+			}
+		},
+		"external-editor": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
+			"integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
+			"dev": true,
+			"requires": {
+				"chardet": "0.4.2",
+				"iconv-lite": "0.4.19",
+				"tmp": "0.0.33"
+			}
+		},
+		"extglob": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+			"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+			"dev": true,
+			"requires": {
+				"array-unique": "0.3.2",
+				"define-property": "1.0.0",
+				"expand-brackets": "2.1.4",
+				"extend-shallow": "2.0.1",
+				"fragment-cache": "0.2.1",
+				"regex-not": "1.0.2",
+				"snapdragon": "0.8.2",
+				"to-regex": "3.0.2"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "1.0.2"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "0.1.1"
+					}
+				}
+			}
+		},
+		"fast-deep-equal": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+			"dev": true
+		},
+		"fast-json-stable-stringify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+			"dev": true
+		},
+		"figures": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+			"dev": true,
+			"requires": {
+				"escape-string-regexp": "1.0.5"
+			}
+		},
+		"filename-regex": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+			"dev": true
+		},
+		"fill-range": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+			"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+			"dev": true,
+			"requires": {
+				"extend-shallow": "2.0.1",
+				"is-number": "3.0.0",
+				"repeat-string": "1.6.1",
+				"to-regex-range": "2.1.1"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "0.1.1"
+					}
+				}
+			}
+		},
+		"find-cache-dir": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
+			"integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
+			"dev": true,
+			"requires": {
+				"commondir": "1.0.1",
+				"make-dir": "1.2.0",
+				"pkg-dir": "2.0.0"
+			}
+		},
 		"find-up": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
@@ -810,16 +2767,997 @@
 				"pinkie-promise": "2.0.1"
 			}
 		},
+		"first-chunk-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
+			"integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
+			"dev": true,
+			"requires": {
+				"readable-stream": "2.3.5"
+			}
+		},
+		"flow-parser": {
+			"version": "0.68.0",
+			"resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.68.0.tgz",
+			"integrity": "sha1-nMlmIKEC4xajFLa81WIFzqzoYtg=",
+			"dev": true
+		},
+		"flush-write-stream": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
+			"integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
+			"dev": true,
+			"requires": {
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.5"
+			}
+		},
+		"for-in": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+			"dev": true
+		},
+		"for-own": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+			"dev": true,
+			"requires": {
+				"for-in": "1.0.2"
+			}
+		},
+		"fragment-cache": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+			"dev": true,
+			"requires": {
+				"map-cache": "0.2.2"
+			}
+		},
+		"from2": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+			"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+			"dev": true,
+			"requires": {
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.5"
+			}
+		},
+		"fs-write-stream-atomic": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+			"integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"iferr": "0.1.5",
+				"imurmurhash": "0.1.4",
+				"readable-stream": "2.3.5"
+			}
+		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 			"dev": true
 		},
+		"fsevents": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+			"integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"nan": "2.10.0",
+				"node-pre-gyp": "0.6.39"
+			},
+			"dependencies": {
+				"abbrev": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"ajv": {
+					"version": "4.11.8",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"co": "4.6.0",
+						"json-stable-stringify": "1.0.1"
+					}
+				},
+				"ansi-regex": {
+					"version": "2.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"aproba": {
+					"version": "1.1.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"are-we-there-yet": {
+					"version": "1.1.4",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"delegates": "1.0.0",
+						"readable-stream": "2.2.9"
+					}
+				},
+				"asn1": {
+					"version": "0.2.3",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"assert-plus": {
+					"version": "0.2.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"asynckit": {
+					"version": "0.4.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"aws-sign2": {
+					"version": "0.6.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"aws4": {
+					"version": "1.6.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"balanced-match": {
+					"version": "0.4.2",
+					"bundled": true,
+					"dev": true
+				},
+				"bcrypt-pbkdf": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"tweetnacl": "0.14.5"
+					}
+				},
+				"block-stream": {
+					"version": "0.0.9",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"inherits": "2.0.3"
+					}
+				},
+				"boom": {
+					"version": "2.10.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"hoek": "2.16.3"
+					}
+				},
+				"brace-expansion": {
+					"version": "1.1.7",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"balanced-match": "0.4.2",
+						"concat-map": "0.0.1"
+					}
+				},
+				"buffer-shims": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"caseless": {
+					"version": "0.12.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"co": {
+					"version": "4.6.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"code-point-at": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"combined-stream": {
+					"version": "1.0.5",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"delayed-stream": "1.0.0"
+					}
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"console-control-strings": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"core-util-is": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"cryptiles": {
+					"version": "2.0.5",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"boom": "2.10.1"
+					}
+				},
+				"dashdash": {
+					"version": "1.14.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"assert-plus": "1.0.0"
+					},
+					"dependencies": {
+						"assert-plus": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						}
+					}
+				},
+				"debug": {
+					"version": "2.6.8",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"deep-extend": {
+					"version": "0.4.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"delayed-stream": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"delegates": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"detect-libc": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"ecc-jsbn": {
+					"version": "0.1.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"jsbn": "0.1.1"
+					}
+				},
+				"extend": {
+					"version": "3.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"extsprintf": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"forever-agent": {
+					"version": "0.6.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"form-data": {
+					"version": "2.1.4",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"asynckit": "0.4.0",
+						"combined-stream": "1.0.5",
+						"mime-types": "2.1.15"
+					}
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"fstream": {
+					"version": "1.0.11",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"inherits": "2.0.3",
+						"mkdirp": "0.5.1",
+						"rimraf": "2.6.1"
+					}
+				},
+				"fstream-ignore": {
+					"version": "1.0.5",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"fstream": "1.0.11",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4"
+					}
+				},
+				"gauge": {
+					"version": "2.7.4",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"aproba": "1.1.1",
+						"console-control-strings": "1.1.0",
+						"has-unicode": "2.0.1",
+						"object-assign": "4.1.1",
+						"signal-exit": "3.0.2",
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wide-align": "1.1.2"
+					}
+				},
+				"getpass": {
+					"version": "0.1.7",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"assert-plus": "1.0.0"
+					},
+					"dependencies": {
+						"assert-plus": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						}
+					}
+				},
+				"glob": {
+					"version": "7.1.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"graceful-fs": {
+					"version": "4.1.11",
+					"bundled": true,
+					"dev": true
+				},
+				"har-schema": {
+					"version": "1.0.5",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"har-validator": {
+					"version": "4.2.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"ajv": "4.11.8",
+						"har-schema": "1.0.5"
+					}
+				},
+				"has-unicode": {
+					"version": "2.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"hawk": {
+					"version": "3.1.3",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"boom": "2.10.1",
+						"cryptiles": "2.0.5",
+						"hoek": "2.16.3",
+						"sntp": "1.0.9"
+					}
+				},
+				"hoek": {
+					"version": "2.16.3",
+					"bundled": true,
+					"dev": true
+				},
+				"http-signature": {
+					"version": "1.1.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"assert-plus": "0.2.0",
+						"jsprim": "1.4.0",
+						"sshpk": "1.13.0"
+					}
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"once": "1.4.0",
+						"wrappy": "1.0.2"
+					}
+				},
+				"inherits": {
+					"version": "2.0.3",
+					"bundled": true,
+					"dev": true
+				},
+				"ini": {
+					"version": "1.3.4",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				},
+				"is-typedarray": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"isstream": {
+					"version": "0.1.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"jodid25519": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"jsbn": "0.1.1"
+					}
+				},
+				"jsbn": {
+					"version": "0.1.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"json-schema": {
+					"version": "0.2.3",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"json-stable-stringify": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"jsonify": "0.0.0"
+					}
+				},
+				"json-stringify-safe": {
+					"version": "5.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"jsonify": {
+					"version": "0.0.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"jsprim": {
+					"version": "1.4.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"assert-plus": "1.0.0",
+						"extsprintf": "1.0.2",
+						"json-schema": "0.2.3",
+						"verror": "1.3.6"
+					},
+					"dependencies": {
+						"assert-plus": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						}
+					}
+				},
+				"mime-db": {
+					"version": "1.27.0",
+					"bundled": true,
+					"dev": true
+				},
+				"mime-types": {
+					"version": "2.1.15",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"mime-db": "1.27.0"
+					}
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"brace-expansion": "1.1.7"
+					}
+				},
+				"minimist": {
+					"version": "0.0.8",
+					"bundled": true,
+					"dev": true
+				},
+				"mkdirp": {
+					"version": "0.5.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"minimist": "0.0.8"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"node-pre-gyp": {
+					"version": "0.6.39",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"detect-libc": "1.0.2",
+						"hawk": "3.1.3",
+						"mkdirp": "0.5.1",
+						"nopt": "4.0.1",
+						"npmlog": "4.1.0",
+						"rc": "1.2.1",
+						"request": "2.81.0",
+						"rimraf": "2.6.1",
+						"semver": "5.3.0",
+						"tar": "2.2.1",
+						"tar-pack": "3.4.0"
+					}
+				},
+				"nopt": {
+					"version": "4.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"abbrev": "1.1.0",
+						"osenv": "0.1.4"
+					}
+				},
+				"npmlog": {
+					"version": "4.1.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"are-we-there-yet": "1.1.4",
+						"console-control-strings": "1.1.0",
+						"gauge": "2.7.4",
+						"set-blocking": "2.0.0"
+					}
+				},
+				"number-is-nan": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"oauth-sign": {
+					"version": "0.8.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"object-assign": {
+					"version": "4.1.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"once": {
+					"version": "1.4.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"wrappy": "1.0.2"
+					}
+				},
+				"os-homedir": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"os-tmpdir": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"osenv": {
+					"version": "0.1.4",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"os-homedir": "1.0.2",
+						"os-tmpdir": "1.0.2"
+					}
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"performance-now": {
+					"version": "0.2.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"process-nextick-args": {
+					"version": "1.0.7",
+					"bundled": true,
+					"dev": true
+				},
+				"punycode": {
+					"version": "1.4.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"qs": {
+					"version": "6.4.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"rc": {
+					"version": "1.2.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"deep-extend": "0.4.2",
+						"ini": "1.3.4",
+						"minimist": "1.2.0",
+						"strip-json-comments": "2.0.1"
+					},
+					"dependencies": {
+						"minimist": {
+							"version": "1.2.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						}
+					}
+				},
+				"readable-stream": {
+					"version": "2.2.9",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"buffer-shims": "1.0.0",
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "1.0.7",
+						"string_decoder": "1.0.1",
+						"util-deprecate": "1.0.2"
+					}
+				},
+				"request": {
+					"version": "2.81.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"aws-sign2": "0.6.0",
+						"aws4": "1.6.0",
+						"caseless": "0.12.0",
+						"combined-stream": "1.0.5",
+						"extend": "3.0.1",
+						"forever-agent": "0.6.1",
+						"form-data": "2.1.4",
+						"har-validator": "4.2.1",
+						"hawk": "3.1.3",
+						"http-signature": "1.1.1",
+						"is-typedarray": "1.0.0",
+						"isstream": "0.1.2",
+						"json-stringify-safe": "5.0.1",
+						"mime-types": "2.1.15",
+						"oauth-sign": "0.8.2",
+						"performance-now": "0.2.0",
+						"qs": "6.4.0",
+						"safe-buffer": "5.0.1",
+						"stringstream": "0.0.5",
+						"tough-cookie": "2.3.2",
+						"tunnel-agent": "0.6.0",
+						"uuid": "3.0.1"
+					}
+				},
+				"rimraf": {
+					"version": "2.6.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"glob": "7.1.2"
+					}
+				},
+				"safe-buffer": {
+					"version": "5.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"semver": {
+					"version": "5.3.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"set-blocking": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"signal-exit": {
+					"version": "3.0.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"sntp": {
+					"version": "1.0.9",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"hoek": "2.16.3"
+					}
+				},
+				"sshpk": {
+					"version": "1.13.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"asn1": "0.2.3",
+						"assert-plus": "1.0.0",
+						"bcrypt-pbkdf": "1.0.1",
+						"dashdash": "1.14.1",
+						"ecc-jsbn": "0.1.1",
+						"getpass": "0.1.7",
+						"jodid25519": "1.0.2",
+						"jsbn": "0.1.1",
+						"tweetnacl": "0.14.5"
+					},
+					"dependencies": {
+						"assert-plus": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						}
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
+					}
+				},
+				"string_decoder": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"safe-buffer": "5.0.1"
+					}
+				},
+				"stringstream": {
+					"version": "0.0.5",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				},
+				"strip-json-comments": {
+					"version": "2.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"tar": {
+					"version": "2.2.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"block-stream": "0.0.9",
+						"fstream": "1.0.11",
+						"inherits": "2.0.3"
+					}
+				},
+				"tar-pack": {
+					"version": "3.4.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"debug": "2.6.8",
+						"fstream": "1.0.11",
+						"fstream-ignore": "1.0.5",
+						"once": "1.4.0",
+						"readable-stream": "2.2.9",
+						"rimraf": "2.6.1",
+						"tar": "2.2.1",
+						"uid-number": "0.0.6"
+					}
+				},
+				"tough-cookie": {
+					"version": "2.3.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"punycode": "1.4.1"
+					}
+				},
+				"tunnel-agent": {
+					"version": "0.6.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"safe-buffer": "5.0.1"
+					}
+				},
+				"tweetnacl": {
+					"version": "0.14.5",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"uid-number": {
+					"version": "0.0.6",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"util-deprecate": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"uuid": {
+					"version": "3.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"verror": {
+					"version": "1.3.6",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"extsprintf": "1.0.2"
+					}
+				},
+				"wide-align": {
+					"version": "1.1.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"string-width": "1.0.2"
+					}
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				}
+			}
+		},
 		"function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
 			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"dev": true
+		},
+		"get-caller-file": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
 			"dev": true
 		},
 		"get-stdin": {
@@ -833,6 +3771,70 @@
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
 			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
 			"dev": true
+		},
+		"get-value": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+			"dev": true
+		},
+		"gh-got": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/gh-got/-/gh-got-6.0.0.tgz",
+			"integrity": "sha512-F/mS+fsWQMo1zfgG9MD8KWvTWPPzzhuVwY++fhQ5Ggd+0P+CAMHtzMZhNxG+TqGfHDChJKsbh6otfMGqO2AKBw==",
+			"dev": true,
+			"requires": {
+				"got": "7.1.0",
+				"is-plain-obj": "1.1.0"
+			},
+			"dependencies": {
+				"got": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
+					"integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
+					"dev": true,
+					"requires": {
+						"decompress-response": "3.3.0",
+						"duplexer3": "0.1.4",
+						"get-stream": "3.0.0",
+						"is-plain-obj": "1.1.0",
+						"is-retry-allowed": "1.1.0",
+						"is-stream": "1.1.0",
+						"isurl": "1.0.0",
+						"lowercase-keys": "1.0.0",
+						"p-cancelable": "0.3.0",
+						"p-timeout": "1.2.1",
+						"safe-buffer": "5.1.1",
+						"timed-out": "4.0.1",
+						"url-parse-lax": "1.0.0",
+						"url-to-options": "1.0.1"
+					}
+				},
+				"p-cancelable": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
+					"integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
+					"dev": true
+				},
+				"p-timeout": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
+					"integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
+					"dev": true,
+					"requires": {
+						"p-finally": "1.0.0"
+					}
+				}
+			}
+		},
+		"github-username": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/github-username/-/github-username-4.1.0.tgz",
+			"integrity": "sha1-y+KABBiDIG2kISrp5LXxacML9Bc=",
+			"dev": true,
+			"requires": {
+				"gh-got": "6.0.0"
+			}
 		},
 		"glob": {
 			"version": "7.1.2",
@@ -848,6 +3850,90 @@
 				"path-is-absolute": "1.0.1"
 			}
 		},
+		"glob-all": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/glob-all/-/glob-all-3.1.0.tgz",
+			"integrity": "sha1-iRPd+17hrHgSZWJBsD1SF8ZLAqs=",
+			"dev": true,
+			"requires": {
+				"glob": "7.1.2",
+				"yargs": "1.2.6"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "0.1.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
+					"integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4=",
+					"dev": true
+				},
+				"yargs": {
+					"version": "1.2.6",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-1.2.6.tgz",
+					"integrity": "sha1-nHtKgv1dWVsr8Xq23MQxNUMv40s=",
+					"dev": true,
+					"requires": {
+						"minimist": "0.1.0"
+					}
+				}
+			}
+		},
+		"glob-base": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+			"dev": true,
+			"requires": {
+				"glob-parent": "2.0.0",
+				"is-glob": "2.0.1"
+			},
+			"dependencies": {
+				"glob-parent": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+					"dev": true,
+					"requires": {
+						"is-glob": "2.0.1"
+					}
+				},
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true,
+					"requires": {
+						"is-extglob": "1.0.0"
+					}
+				}
+			}
+		},
+		"glob-parent": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+			"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+			"dev": true,
+			"requires": {
+				"is-glob": "3.1.0",
+				"path-dirname": "1.0.2"
+			},
+			"dependencies": {
+				"is-glob": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+					"dev": true,
+					"requires": {
+						"is-extglob": "2.1.1"
+					}
+				}
+			}
+		},
 		"global-dirs": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
@@ -856,6 +3942,36 @@
 			"requires": {
 				"ini": "1.3.5"
 			}
+		},
+		"global-modules": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+			"integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+			"dev": true,
+			"requires": {
+				"global-prefix": "1.0.2",
+				"is-windows": "1.0.2",
+				"resolve-dir": "1.0.1"
+			}
+		},
+		"global-prefix": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+			"integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+			"dev": true,
+			"requires": {
+				"expand-tilde": "2.0.2",
+				"homedir-polyfill": "1.0.1",
+				"ini": "1.3.5",
+				"is-windows": "1.0.2",
+				"which": "1.3.0"
+			}
+		},
+		"globals": {
+			"version": "9.18.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+			"dev": true
 		},
 		"globby": {
 			"version": "6.1.0",
@@ -903,6 +4019,15 @@
 			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
 			"dev": true
 		},
+		"grouped-queue": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/grouped-queue/-/grouped-queue-0.3.3.tgz",
+			"integrity": "sha1-wWfSpTGcWg4JZO9qJbfC34mWyFw=",
+			"dev": true,
+			"requires": {
+				"lodash": "4.17.5"
+			}
+		},
 		"has": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
@@ -912,11 +4037,81 @@
 				"function-bind": "1.1.1"
 			}
 		},
+		"has-ansi": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "2.1.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				}
+			}
+		},
+		"has-color": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+			"integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
+			"dev": true
+		},
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 			"dev": true
+		},
+		"has-symbol-support-x": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
+			"integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==",
+			"dev": true
+		},
+		"has-to-string-tag-x": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
+			"integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+			"dev": true,
+			"requires": {
+				"has-symbol-support-x": "1.4.2"
+			}
+		},
+		"has-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+			"dev": true,
+			"requires": {
+				"get-value": "2.0.6",
+				"has-values": "1.0.0",
+				"isobject": "3.0.1"
+			}
+		},
+		"has-values": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+			"dev": true,
+			"requires": {
+				"is-number": "3.0.0",
+				"kind-of": "4.0.0"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "1.1.6"
+					}
+				}
+			}
 		},
 		"hash-base": {
 			"version": "2.0.2",
@@ -948,6 +4143,25 @@
 				"minimalistic-crypto-utils": "1.0.1"
 			}
 		},
+		"home-or-tmp": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+			"dev": true,
+			"requires": {
+				"os-homedir": "1.0.2",
+				"os-tmpdir": "1.0.2"
+			}
+		},
+		"homedir-polyfill": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+			"integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+			"dev": true,
+			"requires": {
+				"parse-passwd": "1.0.0"
+			}
+		},
 		"hosted-git-info": {
 			"version": "2.6.0",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
@@ -960,16 +4174,34 @@
 			"integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E=",
 			"dev": true
 		},
+		"http-cache-semantics": {
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
+			"integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
+			"dev": true
+		},
 		"https-browserify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
 			"integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
 			"dev": true
 		},
+		"iconv-lite": {
+			"version": "0.4.19",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+			"dev": true
+		},
 		"ieee754": {
 			"version": "1.1.8",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
 			"integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
+			"dev": true
+		},
+		"iferr": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+			"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
 			"dev": true
 		},
 		"import-lazy": {
@@ -1036,6 +4268,27 @@
 					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
 					"dev": true
 				}
+			}
+		},
+		"inquirer": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.1.0.tgz",
+			"integrity": "sha512-kn7N70US1MSZHZHSGJLiZ7iCwwncc7b0gc68YtlX29OjI3Mp0tSVV+snVXpZ1G+ONS3Ac9zd1m6hve2ibLDYfA==",
+			"dev": true,
+			"requires": {
+				"ansi-escapes": "3.1.0",
+				"chalk": "2.3.2",
+				"cli-cursor": "2.1.0",
+				"cli-width": "2.2.0",
+				"external-editor": "2.1.0",
+				"figures": "2.0.0",
+				"lodash": "4.17.5",
+				"mute-stream": "0.0.7",
+				"run-async": "2.3.0",
+				"rxjs": "5.5.7",
+				"string-width": "2.1.1",
+				"strip-ansi": "4.0.0",
+				"through": "2.3.8"
 			}
 		},
 		"insert-module-globals": {
@@ -1111,11 +4364,60 @@
 				}
 			}
 		},
+		"interpret": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+			"integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
+			"dev": true
+		},
+		"into-stream": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
+			"integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
+			"dev": true,
+			"requires": {
+				"from2": "2.3.0",
+				"p-is-promise": "1.1.0"
+			}
+		},
+		"invariant": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+			"dev": true,
+			"requires": {
+				"loose-envify": "1.3.1"
+			}
+		},
+		"invert-kv": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+			"dev": true
+		},
+		"is-accessor-descriptor": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+			"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+			"dev": true,
+			"requires": {
+				"kind-of": "6.0.2"
+			}
+		},
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
 			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
 			"dev": true
+		},
+		"is-binary-path": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+			"dev": true,
+			"requires": {
+				"binary-extensions": "1.11.0"
+			}
 		},
 		"is-buffer": {
 			"version": "1.1.6",
@@ -1132,6 +4434,53 @@
 				"builtin-modules": "1.1.1"
 			}
 		},
+		"is-data-descriptor": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+			"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+			"dev": true,
+			"requires": {
+				"kind-of": "6.0.2"
+			}
+		},
+		"is-descriptor": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+			"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+			"dev": true,
+			"requires": {
+				"is-accessor-descriptor": "1.0.0",
+				"is-data-descriptor": "1.0.0",
+				"kind-of": "6.0.2"
+			}
+		},
+		"is-dotfile": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+			"dev": true
+		},
+		"is-equal-shallow": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+			"dev": true,
+			"requires": {
+				"is-primitive": "2.0.0"
+			}
+		},
+		"is-extendable": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"dev": true
+		},
+		"is-extglob": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+			"dev": true
+		},
 		"is-finite": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
@@ -1146,6 +4495,15 @@
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
 			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
 			"dev": true
+		},
+		"is-glob": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+			"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+			"dev": true,
+			"requires": {
+				"is-extglob": "2.1.1"
+			}
 		},
 		"is-installed-globally": {
 			"version": "0.1.0",
@@ -1163,11 +4521,71 @@
 			"integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
 			"dev": true
 		},
+		"is-number": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+			"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+			"dev": true,
+			"requires": {
+				"kind-of": "3.2.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "1.1.6"
+					}
+				}
+			}
+		},
 		"is-obj": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
 			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
 			"dev": true
+		},
+		"is-object": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+			"integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
+			"dev": true
+		},
+		"is-observable": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/is-observable/-/is-observable-0.2.0.tgz",
+			"integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
+			"dev": true,
+			"requires": {
+				"symbol-observable": "0.2.4"
+			},
+			"dependencies": {
+				"symbol-observable": {
+					"version": "0.2.4",
+					"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-0.2.4.tgz",
+					"integrity": "sha1-lag9smGG1q9+ehjb2XYKL4bQj0A=",
+					"dev": true
+				}
+			}
+		},
+		"is-odd": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
+			"integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
+			"dev": true,
+			"requires": {
+				"is-number": "4.0.0"
+			},
+			"dependencies": {
+				"is-number": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+					"dev": true
+				}
+			}
 		},
 		"is-path-cwd": {
 			"version": "1.0.0",
@@ -1193,6 +4611,39 @@
 				"path-is-inside": "1.0.2"
 			}
 		},
+		"is-plain-obj": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+			"dev": true
+		},
+		"is-plain-object": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"dev": true,
+			"requires": {
+				"isobject": "3.0.1"
+			}
+		},
+		"is-posix-bracket": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+			"dev": true
+		},
+		"is-primitive": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+			"dev": true
+		},
+		"is-promise": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+			"dev": true
+		},
 		"is-redirect": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
@@ -1205,6 +4656,15 @@
 			"integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
 			"dev": true
 		},
+		"is-scoped": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-scoped/-/is-scoped-1.0.0.tgz",
+			"integrity": "sha1-RJypgpnnEwOCViieyytUDcQ3yzA=",
+			"dev": true,
+			"requires": {
+				"scoped-regex": "1.0.0"
+			}
+		},
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -1215,6 +4675,12 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
 			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+			"dev": true
+		},
+		"is-windows": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
 			"dev": true
 		},
 		"isarray": {
@@ -1229,6 +4695,188 @@
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
 			"dev": true
 		},
+		"isobject": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+			"dev": true
+		},
+		"istextorbinary": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.2.1.tgz",
+			"integrity": "sha512-TS+hoFl8Z5FAFMK38nhBkdLt44CclNRgDHWeMgsV8ko3nDlr/9UI2Sf839sW7enijf8oKsZYXRvM8g0it9Zmcw==",
+			"dev": true,
+			"requires": {
+				"binaryextensions": "2.1.1",
+				"editions": "1.3.4",
+				"textextensions": "2.2.0"
+			}
+		},
+		"isurl": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
+			"integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
+			"dev": true,
+			"requires": {
+				"has-to-string-tag-x": "1.4.1",
+				"is-object": "1.0.1"
+			}
+		},
+		"js-tokens": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+			"dev": true
+		},
+		"jscodeshift": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.5.0.tgz",
+			"integrity": "sha512-JAcQINNMFpdzzpKJN8k5xXjF3XDuckB1/48uScSzcnNyK199iWEc9AxKL9OoX5144M2w5zEx9Qs4/E/eBZZUlw==",
+			"dev": true,
+			"requires": {
+				"babel-plugin-transform-flow-strip-types": "6.22.0",
+				"babel-preset-es2015": "6.24.1",
+				"babel-preset-stage-1": "6.24.1",
+				"babel-register": "6.26.0",
+				"babylon": "7.0.0-beta.42",
+				"colors": "1.2.1",
+				"flow-parser": "0.68.0",
+				"lodash": "4.17.5",
+				"micromatch": "2.3.11",
+				"neo-async": "2.5.0",
+				"node-dir": "0.1.8",
+				"nomnom": "1.8.1",
+				"recast": "0.14.7",
+				"temp": "0.8.3",
+				"write-file-atomic": "1.3.4"
+			},
+			"dependencies": {
+				"arr-diff": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+					"dev": true,
+					"requires": {
+						"arr-flatten": "1.1.0"
+					}
+				},
+				"array-unique": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+					"dev": true
+				},
+				"braces": {
+					"version": "1.8.5",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+					"dev": true,
+					"requires": {
+						"expand-range": "1.8.2",
+						"preserve": "0.2.0",
+						"repeat-element": "1.1.2"
+					}
+				},
+				"expand-brackets": {
+					"version": "0.1.5",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+					"dev": true,
+					"requires": {
+						"is-posix-bracket": "0.1.1"
+					}
+				},
+				"extglob": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+					"dev": true,
+					"requires": {
+						"is-extglob": "1.0.0"
+					}
+				},
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true,
+					"requires": {
+						"is-extglob": "1.0.0"
+					}
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "1.1.6"
+					}
+				},
+				"micromatch": {
+					"version": "2.3.11",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+					"dev": true,
+					"requires": {
+						"arr-diff": "2.0.0",
+						"array-unique": "0.2.1",
+						"braces": "1.8.5",
+						"expand-brackets": "0.1.5",
+						"extglob": "0.3.2",
+						"filename-regex": "2.0.1",
+						"is-extglob": "1.0.0",
+						"is-glob": "2.0.1",
+						"kind-of": "3.2.2",
+						"normalize-path": "2.1.1",
+						"object.omit": "2.0.1",
+						"parse-glob": "3.0.4",
+						"regex-cache": "0.4.4"
+					}
+				},
+				"write-file-atomic": {
+					"version": "1.3.4",
+					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+					"integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"imurmurhash": "0.1.4",
+						"slide": "1.1.6"
+					}
+				}
+			}
+		},
+		"jsesc": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+			"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+			"dev": true
+		},
+		"json-buffer": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+			"integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
+			"dev": true
+		},
+		"json-parse-better-errors": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
+			"integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw==",
+			"dev": true
+		},
+		"json-schema-traverse": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+			"dev": true
+		},
 		"json-stable-stringify": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
@@ -1237,6 +4885,12 @@
 			"requires": {
 				"jsonify": "0.0.0"
 			}
+		},
+		"json5": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+			"dev": true
 		},
 		"jsonify": {
 			"version": "0.0.0",
@@ -1248,6 +4902,21 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
 			"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
+			"dev": true
+		},
+		"keyv": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
+			"integrity": "sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==",
+			"dev": true,
+			"requires": {
+				"json-buffer": "3.0.0"
+			}
+		},
+		"kind-of": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+			"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
 			"dev": true
 		},
 		"labeled-stream-splicer": {
@@ -1278,6 +4947,15 @@
 				"package-json": "4.0.1"
 			}
 		},
+		"lcid": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+			"dev": true,
+			"requires": {
+				"invert-kv": "1.0.0"
+			}
+		},
 		"lexical-scope": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
@@ -1285,6 +4963,270 @@
 			"dev": true,
 			"requires": {
 				"astw": "2.2.0"
+			}
+		},
+		"listr": {
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/listr/-/listr-0.13.0.tgz",
+			"integrity": "sha1-ILsLowuuZg7oTMBQPfS+PVYjiH0=",
+			"dev": true,
+			"requires": {
+				"chalk": "1.1.3",
+				"cli-truncate": "0.2.1",
+				"figures": "1.7.0",
+				"indent-string": "2.1.0",
+				"is-observable": "0.2.0",
+				"is-promise": "2.1.0",
+				"is-stream": "1.1.0",
+				"listr-silent-renderer": "1.1.1",
+				"listr-update-renderer": "0.4.0",
+				"listr-verbose-renderer": "0.4.1",
+				"log-symbols": "1.0.2",
+				"log-update": "1.0.2",
+				"ora": "0.2.3",
+				"p-map": "1.2.0",
+				"rxjs": "5.5.7",
+				"stream-to-observable": "0.2.0",
+				"strip-ansi": "3.0.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "2.2.1",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "2.0.0",
+						"strip-ansi": "3.0.1",
+						"supports-color": "2.0.0"
+					}
+				},
+				"figures": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+					"dev": true,
+					"requires": {
+						"escape-string-regexp": "1.0.5",
+						"object-assign": "4.1.1"
+					}
+				},
+				"log-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+					"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+					"dev": true,
+					"requires": {
+						"chalk": "1.1.3"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+					"dev": true
+				}
+			}
+		},
+		"listr-silent-renderer": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+			"integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
+			"dev": true
+		},
+		"listr-update-renderer": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.4.0.tgz",
+			"integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
+			"dev": true,
+			"requires": {
+				"chalk": "1.1.3",
+				"cli-truncate": "0.2.1",
+				"elegant-spinner": "1.0.1",
+				"figures": "1.7.0",
+				"indent-string": "3.2.0",
+				"log-symbols": "1.0.2",
+				"log-update": "1.0.2",
+				"strip-ansi": "3.0.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "2.2.1",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "2.0.0",
+						"strip-ansi": "3.0.1",
+						"supports-color": "2.0.0"
+					}
+				},
+				"figures": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+					"dev": true,
+					"requires": {
+						"escape-string-regexp": "1.0.5",
+						"object-assign": "4.1.1"
+					}
+				},
+				"indent-string": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+					"dev": true
+				},
+				"log-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+					"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+					"dev": true,
+					"requires": {
+						"chalk": "1.1.3"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+					"dev": true
+				}
+			}
+		},
+		"listr-verbose-renderer": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
+			"integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
+			"dev": true,
+			"requires": {
+				"chalk": "1.1.3",
+				"cli-cursor": "1.0.2",
+				"date-fns": "1.29.0",
+				"figures": "1.7.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "2.2.1",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "2.0.0",
+						"strip-ansi": "3.0.1",
+						"supports-color": "2.0.0"
+					}
+				},
+				"cli-cursor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+					"dev": true,
+					"requires": {
+						"restore-cursor": "1.0.1"
+					}
+				},
+				"figures": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+					"dev": true,
+					"requires": {
+						"escape-string-regexp": "1.0.5",
+						"object-assign": "4.1.1"
+					}
+				},
+				"onetime": {
+					"version": "1.1.0",
+					"resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+					"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+					"dev": true
+				},
+				"restore-cursor": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+					"dev": true,
+					"requires": {
+						"exit-hook": "1.1.1",
+						"onetime": "1.1.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+					"dev": true
+				}
 			}
 		},
 		"load-json-file": {
@@ -1308,11 +5250,113 @@
 				}
 			}
 		},
+		"loader-runner": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.0.tgz",
+			"integrity": "sha1-9IKuqC1UPgeSFwDVpG7yb9rGuKI=",
+			"dev": true
+		},
+		"loader-utils": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+			"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+			"dev": true,
+			"requires": {
+				"big.js": "3.2.0",
+				"emojis-list": "2.1.0",
+				"json5": "0.5.1"
+			}
+		},
+		"locate-path": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+			"dev": true,
+			"requires": {
+				"p-locate": "2.0.0",
+				"path-exists": "3.0.0"
+			},
+			"dependencies": {
+				"path-exists": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+					"dev": true
+				}
+			}
+		},
+		"lodash": {
+			"version": "4.17.5",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+			"dev": true
+		},
 		"lodash.memoize": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
 			"integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
 			"dev": true
+		},
+		"log-symbols": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+			"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+			"dev": true,
+			"requires": {
+				"chalk": "2.3.2"
+			}
+		},
+		"log-update": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
+			"integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
+			"dev": true,
+			"requires": {
+				"ansi-escapes": "1.4.0",
+				"cli-cursor": "1.0.2"
+			},
+			"dependencies": {
+				"ansi-escapes": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+					"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+					"dev": true
+				},
+				"cli-cursor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+					"dev": true,
+					"requires": {
+						"restore-cursor": "1.0.1"
+					}
+				},
+				"onetime": {
+					"version": "1.1.0",
+					"resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+					"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+					"dev": true
+				},
+				"restore-cursor": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+					"dev": true,
+					"requires": {
+						"exit-hook": "1.1.1",
+						"onetime": "1.1.0"
+					}
+				}
+			}
+		},
+		"loose-envify": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+			"dev": true,
+			"requires": {
+				"js-tokens": "3.0.2"
+			}
 		},
 		"loud-rejection": {
 			"version": "1.6.0",
@@ -1349,11 +5393,26 @@
 				"pify": "3.0.0"
 			}
 		},
+		"map-cache": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+			"dev": true
+		},
 		"map-obj": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
 			"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
 			"dev": true
+		},
+		"map-visit": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+			"dev": true,
+			"requires": {
+				"object-visit": "1.0.1"
+			}
 		},
 		"md5.js": {
 			"version": "1.3.4",
@@ -1377,6 +5436,88 @@
 				}
 			}
 		},
+		"mem": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+			"dev": true,
+			"requires": {
+				"mimic-fn": "1.2.0"
+			}
+		},
+		"mem-fs": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/mem-fs/-/mem-fs-1.1.3.tgz",
+			"integrity": "sha1-uK6NLj/Lb10/kWXBLUVRoGXZicw=",
+			"dev": true,
+			"requires": {
+				"through2": "2.0.3",
+				"vinyl": "1.2.0",
+				"vinyl-file": "2.0.0"
+			}
+		},
+		"mem-fs-editor": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-3.0.2.tgz",
+			"integrity": "sha1-3Qpuryu4prN3QAZ6pUnrUwEFr58=",
+			"dev": true,
+			"requires": {
+				"commondir": "1.0.1",
+				"deep-extend": "0.4.2",
+				"ejs": "2.5.8",
+				"glob": "7.1.2",
+				"globby": "6.1.0",
+				"mkdirp": "0.5.1",
+				"multimatch": "2.1.0",
+				"rimraf": "2.6.2",
+				"through2": "2.0.3",
+				"vinyl": "2.1.0"
+			},
+			"dependencies": {
+				"clone": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+					"dev": true
+				},
+				"clone-stats": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+					"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+					"dev": true
+				},
+				"replace-ext": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+					"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+					"dev": true
+				},
+				"vinyl": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
+					"integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
+					"dev": true,
+					"requires": {
+						"clone": "2.1.2",
+						"clone-buffer": "1.0.0",
+						"clone-stats": "1.0.0",
+						"cloneable-readable": "1.1.2",
+						"remove-trailing-separator": "1.1.0",
+						"replace-ext": "1.0.0"
+					}
+				}
+			}
+		},
+		"memory-fs": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+			"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+			"dev": true,
+			"requires": {
+				"errno": "0.1.7",
+				"readable-stream": "2.3.5"
+			}
+		},
 		"meow": {
 			"version": "3.7.0",
 			"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
@@ -1395,6 +5536,27 @@
 				"trim-newlines": "1.0.0"
 			}
 		},
+		"micromatch": {
+			"version": "3.1.10",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+			"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+			"dev": true,
+			"requires": {
+				"arr-diff": "4.0.0",
+				"array-unique": "0.3.2",
+				"braces": "2.3.1",
+				"define-property": "2.0.2",
+				"extend-shallow": "3.0.2",
+				"extglob": "2.0.4",
+				"fragment-cache": "0.2.1",
+				"kind-of": "6.0.2",
+				"nanomatch": "1.2.9",
+				"object.pick": "1.3.0",
+				"regex-not": "1.0.2",
+				"snapdragon": "0.8.2",
+				"to-regex": "3.0.2"
+			}
+		},
 		"miller-rabin": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
@@ -1404,6 +5566,18 @@
 				"bn.js": "4.11.8",
 				"brorand": "1.1.0"
 			}
+		},
+		"mimic-fn": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+			"dev": true
+		},
+		"mimic-response": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.0.tgz",
+			"integrity": "sha1-3z02Uqc/3ta5sLJBRub9BSNTRY4=",
+			"dev": true
 		},
 		"minimalistic-assert": {
 			"version": "1.0.0",
@@ -1431,6 +5605,45 @@
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 			"dev": true
+		},
+		"mississippi": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
+			"integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
+			"dev": true,
+			"requires": {
+				"concat-stream": "1.6.1",
+				"duplexify": "3.5.4",
+				"end-of-stream": "1.4.1",
+				"flush-write-stream": "1.0.3",
+				"from2": "2.3.0",
+				"parallel-transform": "1.1.0",
+				"pump": "2.0.1",
+				"pumpify": "1.4.0",
+				"stream-each": "1.2.2",
+				"through2": "2.0.3"
+			}
+		},
+		"mixin-deep": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+			"dev": true,
+			"requires": {
+				"for-in": "1.0.2",
+				"is-extendable": "1.0.1"
+			},
+			"dependencies": {
+				"is-extendable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"dev": true,
+					"requires": {
+						"is-plain-object": "2.0.4"
+					}
+				}
+			}
 		},
 		"mkdirp": {
 			"version": "0.5.1",
@@ -1472,6 +5685,189 @@
 				"xtend": "4.0.1"
 			}
 		},
+		"move-concurrently": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+			"integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
+			"dev": true,
+			"requires": {
+				"aproba": "1.2.0",
+				"copy-concurrently": "1.0.5",
+				"fs-write-stream-atomic": "1.0.10",
+				"mkdirp": "0.5.1",
+				"rimraf": "2.6.2",
+				"run-queue": "1.0.3"
+			}
+		},
+		"ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
+		},
+		"multimatch": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+			"integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
+			"dev": true,
+			"requires": {
+				"array-differ": "1.0.0",
+				"array-union": "1.0.2",
+				"arrify": "1.0.1",
+				"minimatch": "3.0.4"
+			}
+		},
+		"mute-stream": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+			"dev": true
+		},
+		"nan": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+			"integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+			"dev": true,
+			"optional": true
+		},
+		"nanomatch": {
+			"version": "1.2.9",
+			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
+			"integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+			"dev": true,
+			"requires": {
+				"arr-diff": "4.0.0",
+				"array-unique": "0.3.2",
+				"define-property": "2.0.2",
+				"extend-shallow": "3.0.2",
+				"fragment-cache": "0.2.1",
+				"is-odd": "2.0.0",
+				"is-windows": "1.0.2",
+				"kind-of": "6.0.2",
+				"object.pick": "1.3.0",
+				"regex-not": "1.0.2",
+				"snapdragon": "0.8.2",
+				"to-regex": "3.0.2"
+			}
+		},
+		"neo-async": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.5.0.tgz",
+			"integrity": "sha512-nJmSswG4As/MkRq7QZFuH/sf/yuv8ODdMZrY4Bedjp77a5MK4A6s7YbBB64c9u79EBUOfXUXBvArmvzTD0X+6g==",
+			"dev": true
+		},
+		"nice-try": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.4.tgz",
+			"integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA==",
+			"dev": true
+		},
+		"node-dir": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.8.tgz",
+			"integrity": "sha1-VfuN62mQcHB/tn+RpGDwRIKUx30=",
+			"dev": true
+		},
+		"node-libs-browser": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
+			"integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
+			"dev": true,
+			"requires": {
+				"assert": "1.4.1",
+				"browserify-zlib": "0.2.0",
+				"buffer": "4.9.1",
+				"console-browserify": "1.1.0",
+				"constants-browserify": "1.0.0",
+				"crypto-browserify": "3.12.0",
+				"domain-browser": "1.2.0",
+				"events": "1.1.1",
+				"https-browserify": "1.0.0",
+				"os-browserify": "0.3.0",
+				"path-browserify": "0.0.0",
+				"process": "0.11.10",
+				"punycode": "1.4.1",
+				"querystring-es3": "0.2.1",
+				"readable-stream": "2.3.5",
+				"stream-browserify": "2.0.1",
+				"stream-http": "2.8.0",
+				"string_decoder": "1.0.3",
+				"timers-browserify": "2.0.6",
+				"tty-browserify": "0.0.0",
+				"url": "0.11.0",
+				"util": "0.10.3",
+				"vm-browserify": "0.0.4"
+			},
+			"dependencies": {
+				"buffer": {
+					"version": "4.9.1",
+					"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+					"integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+					"dev": true,
+					"requires": {
+						"base64-js": "1.2.3",
+						"ieee754": "1.1.8",
+						"isarray": "1.0.0"
+					}
+				},
+				"events": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+					"integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+					"dev": true
+				},
+				"timers-browserify": {
+					"version": "2.0.6",
+					"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.6.tgz",
+					"integrity": "sha512-HQ3nbYRAowdVd0ckGFvmJPPCOH/CHleFN/Y0YQCX1DVaB7t+KFvisuyN09fuP8Jtp1CpfSh8O8bMkHbdbPe6Pw==",
+					"dev": true,
+					"requires": {
+						"setimmediate": "1.0.5"
+					}
+				},
+				"tty-browserify": {
+					"version": "0.0.0",
+					"resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+					"integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
+					"dev": true
+				}
+			}
+		},
+		"nomnom": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
+			"integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
+			"dev": true,
+			"requires": {
+				"chalk": "0.4.0",
+				"underscore": "1.6.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+					"integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
+					"dev": true
+				},
+				"chalk": {
+					"version": "0.4.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+					"integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "1.0.0",
+						"has-color": "0.1.7",
+						"strip-ansi": "0.1.1"
+					}
+				},
+				"strip-ansi": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+					"integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
+					"dev": true
+				}
+			}
+		},
 		"normalize-package-data": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -1482,6 +5878,34 @@
 				"is-builtin-module": "1.0.0",
 				"semver": "5.5.0",
 				"validate-npm-package-license": "3.0.3"
+			}
+		},
+		"normalize-path": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+			"dev": true,
+			"requires": {
+				"remove-trailing-separator": "1.1.0"
+			}
+		},
+		"normalize-url": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
+			"integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
+			"dev": true,
+			"requires": {
+				"prepend-http": "2.0.0",
+				"query-string": "5.1.1",
+				"sort-keys": "2.0.0"
+			},
+			"dependencies": {
+				"prepend-http": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+					"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+					"dev": true
+				}
 			}
 		},
 		"npm-run-path": {
@@ -1505,6 +5929,102 @@
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
 			"dev": true
 		},
+		"object-copy": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+			"dev": true,
+			"requires": {
+				"copy-descriptor": "0.1.1",
+				"define-property": "0.2.5",
+				"kind-of": "3.2.2"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "0.1.6"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"dev": true,
+					"requires": {
+						"kind-of": "3.2.2"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"dev": true,
+					"requires": {
+						"kind-of": "3.2.2"
+					}
+				},
+				"is-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "0.1.6",
+						"is-data-descriptor": "0.1.4",
+						"kind-of": "5.1.0"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+							"dev": true
+						}
+					}
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "1.1.6"
+					}
+				}
+			}
+		},
+		"object-visit": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+			"dev": true,
+			"requires": {
+				"isobject": "3.0.1"
+			}
+		},
+		"object.omit": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+			"dev": true,
+			"requires": {
+				"for-own": "0.1.5",
+				"is-extendable": "0.1.1"
+			}
+		},
+		"object.pick": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+			"dev": true,
+			"requires": {
+				"isobject": "3.0.1"
+			}
+		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -1514,11 +6034,137 @@
 				"wrappy": "1.0.2"
 			}
 		},
+		"onetime": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+			"dev": true,
+			"requires": {
+				"mimic-fn": "1.2.0"
+			}
+		},
+		"ora": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
+			"integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
+			"dev": true,
+			"requires": {
+				"chalk": "1.1.3",
+				"cli-cursor": "1.0.2",
+				"cli-spinners": "0.1.2",
+				"object-assign": "4.1.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "2.2.1",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "2.0.0",
+						"strip-ansi": "3.0.1",
+						"supports-color": "2.0.0"
+					}
+				},
+				"cli-cursor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+					"dev": true,
+					"requires": {
+						"restore-cursor": "1.0.1"
+					}
+				},
+				"onetime": {
+					"version": "1.1.0",
+					"resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+					"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+					"dev": true
+				},
+				"restore-cursor": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+					"dev": true,
+					"requires": {
+						"exit-hook": "1.1.1",
+						"onetime": "1.1.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+					"dev": true
+				}
+			}
+		},
 		"os-browserify": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
 			"integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
 			"dev": true
+		},
+		"os-homedir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+			"dev": true
+		},
+		"os-locale": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+			"dev": true,
+			"requires": {
+				"execa": "0.7.0",
+				"lcid": "1.0.0",
+				"mem": "1.1.0"
+			}
+		},
+		"os-tmpdir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+			"dev": true
+		},
+		"p-cancelable": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.0.tgz",
+			"integrity": "sha512-/AodqPe1y/GYbhSlnMjxukLGQfQIgsmjSy2CXCNB96kg4ozKvmlovuHEKICToOO/yS3LLWgrWI1dFtFfrePS1g==",
+			"dev": true
+		},
+		"p-each-series": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
+			"integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
+			"dev": true,
+			"requires": {
+				"p-reduce": "1.0.0"
+			}
 		},
 		"p-finally": {
 			"version": "1.0.0",
@@ -1526,10 +6172,67 @@
 			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
 			"dev": true
 		},
+		"p-is-promise": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+			"integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
+			"dev": true
+		},
+		"p-lazy": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-lazy/-/p-lazy-1.0.0.tgz",
+			"integrity": "sha1-7FPIAvLuOsKPFmzILQsrAt4nqDU=",
+			"dev": true
+		},
+		"p-limit": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+			"integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+			"dev": true,
+			"requires": {
+				"p-try": "1.0.0"
+			}
+		},
+		"p-locate": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+			"dev": true,
+			"requires": {
+				"p-limit": "1.2.0"
+			}
+		},
 		"p-map": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
 			"integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+			"dev": true
+		},
+		"p-reduce": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
+			"integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
+			"dev": true
+		},
+		"p-timeout": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
+			"integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
+			"dev": true,
+			"requires": {
+				"p-finally": "1.0.0"
+			}
+		},
+		"p-try": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+			"dev": true
+		},
+		"package": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/package/-/package-1.0.1.tgz",
+			"integrity": "sha1-0lofmeJQbcsn1nBLg9yooxLk7cw=",
 			"dev": true
 		},
 		"package-json": {
@@ -1549,6 +6252,17 @@
 			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
 			"integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
 			"dev": true
+		},
+		"parallel-transform": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
+			"integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
+			"dev": true,
+			"requires": {
+				"cyclist": "0.2.2",
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.5"
+			}
 		},
 		"parents": {
 			"version": "1.0.1",
@@ -1572,6 +6286,35 @@
 				"pbkdf2": "3.0.14"
 			}
 		},
+		"parse-glob": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+			"dev": true,
+			"requires": {
+				"glob-base": "0.3.0",
+				"is-dotfile": "1.0.3",
+				"is-extglob": "1.0.0",
+				"is-glob": "2.0.1"
+			},
+			"dependencies": {
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true,
+					"requires": {
+						"is-extglob": "1.0.0"
+					}
+				}
+			}
+		},
 		"parse-json": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
@@ -1581,10 +6324,28 @@
 				"error-ex": "1.3.1"
 			}
 		},
+		"parse-passwd": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+			"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+			"dev": true
+		},
+		"pascalcase": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+			"dev": true
+		},
 		"path-browserify": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
 			"integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
+			"dev": true
+		},
+		"path-dirname": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
 			"dev": true
 		},
 		"path-exists": {
@@ -1679,16 +6440,60 @@
 				"pinkie": "2.0.4"
 			}
 		},
+		"pkg-dir": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+			"dev": true,
+			"requires": {
+				"find-up": "2.1.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"dev": true,
+					"requires": {
+						"locate-path": "2.0.0"
+					}
+				}
+			}
+		},
+		"posix-character-classes": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+			"dev": true
+		},
 		"prepend-http": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
 			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
 			"dev": true
 		},
+		"preserve": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+			"dev": true
+		},
 		"prettier": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.11.1.tgz",
 			"integrity": "sha512-T/KD65Ot0PB97xTrG8afQ46x3oiVhnfGjGESSI9NWYcG92+OUPZKkwHqGWXH2t9jK1crnQjubECW0FuOth+hxw==",
+			"dev": true
+		},
+		"pretty-bytes": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
+			"integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk=",
+			"dev": true
+		},
+		"private": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
 			"dev": true
 		},
 		"process": {
@@ -1701,6 +6506,18 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
 			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+			"dev": true
+		},
+		"promise-inflight": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+			"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
+			"dev": true
+		},
+		"prr": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
 			"dev": true
 		},
 		"pseudomap": {
@@ -1722,11 +6539,43 @@
 				"randombytes": "2.0.6"
 			}
 		},
+		"pump": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+			"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+			"dev": true,
+			"requires": {
+				"end-of-stream": "1.4.1",
+				"once": "1.4.0"
+			}
+		},
+		"pumpify": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.4.0.tgz",
+			"integrity": "sha512-2kmNR9ry+Pf45opRVirpNuIFotsxUGLaYqxIwuR77AYrYRMuFCz9eryHBS52L360O+NcR383CL4QYlMKPq4zYA==",
+			"dev": true,
+			"requires": {
+				"duplexify": "3.5.4",
+				"inherits": "2.0.3",
+				"pump": "2.0.1"
+			}
+		},
 		"punycode": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
 			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
 			"dev": true
+		},
+		"query-string": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+			"integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+			"dev": true,
+			"requires": {
+				"decode-uri-component": "0.2.0",
+				"object-assign": "4.1.1",
+				"strict-uri-encode": "1.1.0"
+			}
 		},
 		"querystring": {
 			"version": "0.2.0",
@@ -1739,6 +6588,27 @@
 			"resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
 			"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
 			"dev": true
+		},
+		"randomatic": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+			"dev": true,
+			"requires": {
+				"is-number": "3.0.0",
+				"kind-of": "4.0.0"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "1.1.6"
+					}
+				}
+			}
 		},
 		"randombytes": {
 			"version": "2.0.6",
@@ -1769,6 +6639,16 @@
 				"ini": "1.3.5",
 				"minimist": "1.2.0",
 				"strip-json-comments": "2.0.1"
+			}
+		},
+		"read-chunk": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-2.1.0.tgz",
+			"integrity": "sha1-agTAkoAF7Z1C4aasVgDhnLx/9lU=",
+			"dev": true,
+			"requires": {
+				"pify": "3.0.0",
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"read-only-stream": {
@@ -1816,6 +6696,39 @@
 				"util-deprecate": "1.0.2"
 			}
 		},
+		"readdirp": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"minimatch": "3.0.4",
+				"readable-stream": "2.3.5",
+				"set-immediate-shim": "1.0.1"
+			}
+		},
+		"recast": {
+			"version": "0.14.7",
+			"resolved": "https://registry.npmjs.org/recast/-/recast-0.14.7.tgz",
+			"integrity": "sha512-/nwm9pkrcWagN40JeJhkPaRxiHXBRkXyRh/hgU088Z/v+qCy+zIHHY6bC6o7NaKAxPqtE6nD8zBH1LfU0/Wx6A==",
+			"dev": true,
+			"requires": {
+				"ast-types": "0.11.3",
+				"esprima": "4.0.0",
+				"private": "0.1.8",
+				"source-map": "0.6.1"
+			}
+		},
+		"rechoir": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+			"dev": true,
+			"requires": {
+				"resolve": "1.5.0"
+			}
+		},
 		"redent": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
@@ -1824,6 +6737,59 @@
 			"requires": {
 				"indent-string": "2.1.0",
 				"strip-indent": "1.0.1"
+			}
+		},
+		"regenerate": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
+			"integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
+			"dev": true
+		},
+		"regenerator-runtime": {
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+			"dev": true
+		},
+		"regenerator-transform": {
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
+			"integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"private": "0.1.8"
+			}
+		},
+		"regex-cache": {
+			"version": "0.4.4",
+			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+			"dev": true,
+			"requires": {
+				"is-equal-shallow": "0.1.3"
+			}
+		},
+		"regex-not": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+			"dev": true,
+			"requires": {
+				"extend-shallow": "3.0.2",
+				"safe-regex": "1.1.0"
+			}
+		},
+		"regexpu-core": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
+			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+			"dev": true,
+			"requires": {
+				"regenerate": "1.3.3",
+				"regjsgen": "0.2.0",
+				"regjsparser": "0.1.5"
 			}
 		},
 		"registry-auth-token": {
@@ -1845,6 +6811,39 @@
 				"rc": "1.2.5"
 			}
 		},
+		"regjsgen": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+			"dev": true
+		},
+		"regjsparser": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+			"dev": true,
+			"requires": {
+				"jsesc": "0.5.0"
+			}
+		},
+		"remove-trailing-separator": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+			"dev": true
+		},
+		"repeat-element": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+			"dev": true
+		},
+		"repeat-string": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+			"dev": true
+		},
 		"repeating": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
@@ -1854,6 +6853,24 @@
 				"is-finite": "1.0.2"
 			}
 		},
+		"replace-ext": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+			"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+			"dev": true
+		},
+		"require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+			"dev": true
+		},
+		"require-main-filename": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+			"dev": true
+		},
 		"resolve": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
@@ -1862,6 +6879,62 @@
 			"requires": {
 				"path-parse": "1.0.5"
 			}
+		},
+		"resolve-cwd": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+			"dev": true,
+			"requires": {
+				"resolve-from": "3.0.0"
+			}
+		},
+		"resolve-dir": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+			"integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+			"dev": true,
+			"requires": {
+				"expand-tilde": "2.0.2",
+				"global-modules": "1.0.0"
+			}
+		},
+		"resolve-from": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+			"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+			"dev": true
+		},
+		"resolve-url": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+			"dev": true
+		},
+		"responselike": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+			"integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+			"dev": true,
+			"requires": {
+				"lowercase-keys": "1.0.0"
+			}
+		},
+		"restore-cursor": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+			"dev": true,
+			"requires": {
+				"onetime": "2.0.1",
+				"signal-exit": "3.0.2"
+			}
+		},
+		"ret": {
+			"version": "0.1.15",
+			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+			"dev": true
 		},
 		"rimraf": {
 			"version": "2.6.2",
@@ -1882,10 +6955,77 @@
 				"inherits": "2.0.3"
 			}
 		},
+		"run-async": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+			"dev": true,
+			"requires": {
+				"is-promise": "2.1.0"
+			}
+		},
+		"run-queue": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
+			"integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
+			"dev": true,
+			"requires": {
+				"aproba": "1.2.0"
+			}
+		},
+		"rx-lite": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+			"dev": true
+		},
+		"rx-lite-aggregates": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+			"dev": true,
+			"requires": {
+				"rx-lite": "4.0.8"
+			}
+		},
+		"rxjs": {
+			"version": "5.5.7",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.7.tgz",
+			"integrity": "sha512-Hxo2ac8gRQjwjtKgukMIwBRbq5+KAeEV5hXM4obYBOAghev41bDQWgFH4svYiU9UnQ5kNww2LgfyBdevCd2HXA==",
+			"dev": true,
+			"requires": {
+				"symbol-observable": "1.0.1"
+			}
+		},
 		"safe-buffer": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
 			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+			"dev": true
+		},
+		"safe-regex": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+			"dev": true,
+			"requires": {
+				"ret": "0.1.15"
+			}
+		},
+		"schema-utils": {
+			"version": "0.4.5",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.5.tgz",
+			"integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
+			"dev": true,
+			"requires": {
+				"ajv": "6.4.0",
+				"ajv-keywords": "3.1.0"
+			}
+		},
+		"scoped-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/scoped-regex/-/scoped-regex-1.0.0.tgz",
+			"integrity": "sha1-o0a7Gs1CB65wvXwMfKnlZra63bg=",
 			"dev": true
 		},
 		"semver": {
@@ -1902,6 +7042,53 @@
 			"requires": {
 				"semver": "5.5.0"
 			}
+		},
+		"serialize-javascript": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.4.0.tgz",
+			"integrity": "sha1-fJWFFNtqwkQ6irwGLcn3iGp/YAU=",
+			"dev": true
+		},
+		"set-blocking": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+			"dev": true
+		},
+		"set-immediate-shim": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+			"dev": true
+		},
+		"set-value": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+			"dev": true,
+			"requires": {
+				"extend-shallow": "2.0.1",
+				"is-extendable": "0.1.1",
+				"is-plain-object": "2.0.4",
+				"split-string": "3.1.0"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "0.1.1"
+					}
+				}
+			}
+		},
+		"setimmediate": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+			"dev": true
 		},
 		"sha.js": {
 			"version": "2.4.10",
@@ -1950,16 +7137,237 @@
 				"jsonify": "0.0.0"
 			}
 		},
+		"shelljs": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.1.tgz",
+			"integrity": "sha512-YA/iYtZpzFe5HyWVGrb02FjPxc4EMCfpoU/Phg9fQoyMC72u9598OUBrsU8IrtwAKG0tO8IYaqbaLIw+k3IRGA==",
+			"dev": true,
+			"requires": {
+				"glob": "7.1.2",
+				"interpret": "1.1.0",
+				"rechoir": "0.6.2"
+			}
+		},
 		"signal-exit": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
 			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 			"dev": true
 		},
+		"slash": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+			"dev": true
+		},
+		"slice-ansi": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+			"integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+			"dev": true
+		},
+		"slide": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+			"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+			"dev": true
+		},
+		"snapdragon": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+			"dev": true,
+			"requires": {
+				"base": "0.11.2",
+				"debug": "2.6.9",
+				"define-property": "0.2.5",
+				"extend-shallow": "2.0.1",
+				"map-cache": "0.2.2",
+				"source-map": "0.5.7",
+				"source-map-resolve": "0.5.1",
+				"use": "3.1.0"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "0.1.6"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "0.1.1"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"dev": true,
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"dev": true,
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "0.1.6",
+						"is-data-descriptor": "0.1.4",
+						"kind-of": "5.1.0"
+					}
+				},
+				"kind-of": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
+			}
+		},
+		"snapdragon-node": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+			"dev": true,
+			"requires": {
+				"define-property": "1.0.0",
+				"isobject": "3.0.1",
+				"snapdragon-util": "3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "1.0.2"
+					}
+				}
+			}
+		},
+		"snapdragon-util": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+			"dev": true,
+			"requires": {
+				"kind-of": "3.2.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "1.1.6"
+					}
+				}
+			}
+		},
+		"sort-keys": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
+			"integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+			"dev": true,
+			"requires": {
+				"is-plain-obj": "1.1.0"
+			}
+		},
+		"source-list-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
+			"integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A==",
+			"dev": true
+		},
 		"source-map": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true
+		},
+		"source-map-resolve": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
+			"integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
+			"dev": true,
+			"requires": {
+				"atob": "2.0.3",
+				"decode-uri-component": "0.2.0",
+				"resolve-url": "0.2.1",
+				"source-map-url": "0.4.0",
+				"urix": "0.1.0"
+			}
+		},
+		"source-map-support": {
+			"version": "0.4.18",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+			"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+			"dev": true,
+			"requires": {
+				"source-map": "0.5.7"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
+			}
+		},
+		"source-map-url": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
 			"dev": true
 		},
 		"spdx-correct": {
@@ -1994,37 +7402,135 @@
 			"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
 			"dev": true
 		},
+		"split-string": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+			"dev": true,
+			"requires": {
+				"extend-shallow": "3.0.2"
+			}
+		},
+		"ssri": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
+			"integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"static-extend": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+			"dev": true,
+			"requires": {
+				"define-property": "0.2.5",
+				"object-copy": "0.1.0"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "0.1.6"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"dev": true,
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"dev": true,
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "0.1.6",
+						"is-data-descriptor": "0.1.4",
+						"kind-of": "5.1.0"
+					}
+				},
+				"kind-of": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+					"dev": true
+				}
+			}
+		},
 		"ste-core": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/ste-core/-/ste-core-1.3.4.tgz",
-			"integrity": "sha512-NK2fxZP+BlrGBD5jzcL9ygJv9RmTaEVJ97jPJggLgiXVFwC4D2UGZYrob1y2HvSma8TMQTCoT7R8qJYP43vLrw==",
+			"version": "1.3.12",
+			"resolved": "https://registry.npmjs.org/ste-core/-/ste-core-1.3.12.tgz",
+			"integrity": "sha512-rHEag6eFM7fibdyxnlJTHRfA2vCfzk/VmlXoBn+N3be5ZvDtYdOUbyQJg4x1ATTzOyHSoMrfw1HVdLVY8VYT+w==",
 			"dev": true
 		},
 		"ste-events": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/ste-events/-/ste-events-1.3.4.tgz",
-			"integrity": "sha512-C3p/10jXcr4QMA+oVR2etmIPVYEG6rKVpJ1gPobQRlpqZcxCHnao58efLXlyd9xVKFhe8R9pvT/btwnos9KihA==",
+			"version": "1.3.12",
+			"resolved": "https://registry.npmjs.org/ste-events/-/ste-events-1.3.12.tgz",
+			"integrity": "sha512-nvWY0E/+t0rjci2ED8vFHSOxVvbbLdTUO+ILl2XcZl78BIlv0JBDE++g7Jery5t+8aPqpxIHxTwT7q4PZZCaIQ==",
 			"dev": true,
 			"requires": {
-				"ste-core": "1.3.4"
+				"del-cli": "1.1.0",
+				"package": "1.0.1",
+				"ste-core": "1.3.12"
 			}
 		},
 		"ste-signals": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/ste-signals/-/ste-signals-1.3.4.tgz",
-			"integrity": "sha512-LIZ63uAkeW0aWMy4fHgDf7hrOH0IJK90a9QazNrY0rVHUV1Xmj0tJzKllc17J9QeNdddwzjqgC/qcqTWZ/h0/Q==",
+			"version": "1.3.12",
+			"resolved": "https://registry.npmjs.org/ste-signals/-/ste-signals-1.3.12.tgz",
+			"integrity": "sha512-QYLSXBGgT2Ka9d1aW0/8/QBmGdtqZVZIeKC9S1amnU1mXU1i3/fPV+G7BNhBLZ3NhT0KeJ4ZDsDqSMspzbJFNw==",
 			"dev": true,
 			"requires": {
-				"ste-core": "1.3.4"
+				"ste-core": "1.3.12"
 			}
 		},
 		"ste-simple-events": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/ste-simple-events/-/ste-simple-events-1.3.4.tgz",
-			"integrity": "sha512-yIGPDqUqb8JrJVIJ12ra4RhSrQgmphFMPuWV0uBsiIbak2vfV5wDNICBZ2XMIGiMXSSfvctNo5n/sLajuU7SIA==",
+			"version": "1.3.12",
+			"resolved": "https://registry.npmjs.org/ste-simple-events/-/ste-simple-events-1.3.12.tgz",
+			"integrity": "sha512-BVB7X/bVcHOnHV9anw0Euseuppo57dDjNDHkrUJId/p6IWcuem32tjIeWu15IM+R3Ng8vLB6Q+KMu4LANBcUhw==",
 			"dev": true,
 			"requires": {
-				"ste-core": "1.3.4"
+				"ste-core": "1.3.12"
 			}
 		},
 		"stream-browserify": {
@@ -2047,6 +7553,16 @@
 				"readable-stream": "2.3.5"
 			}
 		},
+		"stream-each": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
+			"integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
+			"dev": true,
+			"requires": {
+				"end-of-stream": "1.4.1",
+				"stream-shift": "1.0.0"
+			}
+		},
 		"stream-http": {
 			"version": "2.8.0",
 			"resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.0.tgz",
@@ -2060,6 +7576,12 @@
 				"xtend": "4.0.1"
 			}
 		},
+		"stream-shift": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+			"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
+			"dev": true
+		},
 		"stream-splicer": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.0.tgz",
@@ -2069,6 +7591,27 @@
 				"inherits": "2.0.3",
 				"readable-stream": "2.3.5"
 			}
+		},
+		"stream-to-observable": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/stream-to-observable/-/stream-to-observable-0.2.0.tgz",
+			"integrity": "sha1-WdbqOT2HwsDdrBCqDVYbxrpvDhA=",
+			"dev": true,
+			"requires": {
+				"any-observable": "0.2.0"
+			}
+		},
+		"strict-uri-encode": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+			"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+			"dev": true
+		},
+		"string-template": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
+			"integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0=",
+			"dev": true
 		},
 		"string-width": {
 			"version": "2.1.1",
@@ -2107,6 +7650,16 @@
 				"is-utf8": "0.2.1"
 			}
 		},
+		"strip-bom-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-2.0.0.tgz",
+			"integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
+			"dev": true,
+			"requires": {
+				"first-chunk-stream": "2.0.0",
+				"strip-bom": "2.0.0"
+			}
+		},
 		"strip-eof": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
@@ -2129,15 +7682,15 @@
 			"dev": true
 		},
 		"strongly-typed-events": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/strongly-typed-events/-/strongly-typed-events-1.3.4.tgz",
-			"integrity": "sha512-yP0J0wWrIDON6V7LqLlYTV59mNg6OD3/Tr4kl2yzQP9WhUKJCXPpa8SRrq6nhNQyrlPYl1L0PYYf9pLUlFZgXQ==",
+			"version": "1.3.12",
+			"resolved": "https://registry.npmjs.org/strongly-typed-events/-/strongly-typed-events-1.3.12.tgz",
+			"integrity": "sha512-QC9ZWDUqV3MqmvzhD4hc6wtV7r/nJzbVYU6Dv9nSGrRtJc/c0I1gq86qVQT02iQeBrVOxAoqdTxmbZw0hHuqIg==",
 			"dev": true,
 			"requires": {
-				"ste-core": "1.3.4",
-				"ste-events": "1.3.4",
-				"ste-signals": "1.3.4",
-				"ste-simple-events": "1.3.4"
+				"ste-core": "1.3.12",
+				"ste-events": "1.3.12",
+				"ste-signals": "1.3.12",
+				"ste-simple-events": "1.3.12"
 			}
 		},
 		"subarg": {
@@ -2158,6 +7711,12 @@
 				"has-flag": "3.0.0"
 			}
 		},
+		"symbol-observable": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+			"integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
+			"dev": true
+		},
 		"syntax-error": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.4.0.tgz",
@@ -2165,6 +7724,30 @@
 			"dev": true,
 			"requires": {
 				"acorn-node": "1.3.0"
+			}
+		},
+		"tapable": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-1.0.0.tgz",
+			"integrity": "sha512-dQRhbNQkRnaqauC7WqSJ21EEksgT0fYZX2lqXzGkpo8JNig9zGZTYoMGvyI2nWmXlE2VSVXVDu7wLVGu/mQEsg==",
+			"dev": true
+		},
+		"temp": {
+			"version": "0.8.3",
+			"resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
+			"integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
+			"dev": true,
+			"requires": {
+				"os-tmpdir": "1.0.2",
+				"rimraf": "2.2.8"
+			},
+			"dependencies": {
+				"rimraf": {
+					"version": "2.2.8",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+					"integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+					"dev": true
+				}
 			}
 		},
 		"term-size": {
@@ -2175,6 +7758,18 @@
 			"requires": {
 				"execa": "0.7.0"
 			}
+		},
+		"text-table": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+			"dev": true
+		},
+		"textextensions": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.2.0.tgz",
+			"integrity": "sha512-j5EMxnryTvKxwH2Cq+Pb43tsf6sdEgw6Pdwxk83mPaq0ToeFJt6WE4J3s5BqY7vmjlLgkgXvhtXUxo80FyBhCA==",
+			"dev": true
 		},
 		"through": {
 			"version": "2.3.8",
@@ -2207,16 +7802,79 @@
 				"process": "0.11.10"
 			}
 		},
+		"tmp": {
+			"version": "0.0.33",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+			"dev": true,
+			"requires": {
+				"os-tmpdir": "1.0.2"
+			}
+		},
 		"to-arraybuffer": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
 			"integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
 			"dev": true
 		},
+		"to-fast-properties": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+			"dev": true
+		},
+		"to-object-path": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+			"dev": true,
+			"requires": {
+				"kind-of": "3.2.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "1.1.6"
+					}
+				}
+			}
+		},
+		"to-regex": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+			"dev": true,
+			"requires": {
+				"define-property": "2.0.2",
+				"extend-shallow": "3.0.2",
+				"regex-not": "1.0.2",
+				"safe-regex": "1.1.0"
+			}
+		},
+		"to-regex-range": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+			"dev": true,
+			"requires": {
+				"is-number": "3.0.0",
+				"repeat-string": "1.6.1"
+			}
+		},
 		"trim-newlines": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
 			"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+			"dev": true
+		},
+		"trim-right": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
 			"dev": true
 		},
 		"tty-browserify": {
@@ -2231,22 +7889,30 @@
 			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
 			"dev": true
 		},
-		"uglify-js": {
-			"version": "3.3.13",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.13.tgz",
-			"integrity": "sha512-7rdn/bDOG1ElSTPdh7AI5TCjLv63ZD4k8BBadN3ssIkhlaQL2c0yRxmXCyOYhZK0wZTgGgUSnYQ4CGu+Jos5cA==",
+		"uglify-es": {
+			"version": "3.3.9",
+			"resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
+			"integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
 			"dev": true,
 			"requires": {
-				"commander": "2.14.1",
+				"commander": "2.13.0",
 				"source-map": "0.6.1"
-			},
-			"dependencies": {
-				"commander": {
-					"version": "2.14.1",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
-					"integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
-					"dev": true
-				}
+			}
+		},
+		"uglifyjs-webpack-plugin": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.2.4.tgz",
+			"integrity": "sha512-z0IbjpW8b3O/OVn+TTZN4pI29RN1zktFBXLIzzfZ+++cUtZ1ERSlLWgpE/5OERuEUs1ijVQnpYAkSlpoVmQmSQ==",
+			"dev": true,
+			"requires": {
+				"cacache": "10.0.4",
+				"find-cache-dir": "1.0.0",
+				"schema-utils": "0.4.5",
+				"serialize-javascript": "1.4.0",
+				"source-map": "0.6.1",
+				"uglify-es": "3.3.9",
+				"webpack-sources": "1.1.0",
+				"worker-farm": "1.6.0"
 			}
 		},
 		"umd": {
@@ -2254,6 +7920,65 @@
 			"resolved": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz",
 			"integrity": "sha1-iuVW4RAR9jwllnCKiDclnwGz1g4=",
 			"dev": true
+		},
+		"underscore": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+			"integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
+			"dev": true
+		},
+		"union-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+			"dev": true,
+			"requires": {
+				"arr-union": "3.1.0",
+				"get-value": "2.0.6",
+				"is-extendable": "0.1.1",
+				"set-value": "0.4.3"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "0.1.1"
+					}
+				},
+				"set-value": {
+					"version": "0.4.3",
+					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+					"dev": true,
+					"requires": {
+						"extend-shallow": "2.0.1",
+						"is-extendable": "0.1.1",
+						"is-plain-object": "2.0.4",
+						"to-object-path": "0.3.0"
+					}
+				}
+			}
+		},
+		"unique-filename": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
+			"integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
+			"dev": true,
+			"requires": {
+				"unique-slug": "2.0.0"
+			}
+		},
+		"unique-slug": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
+			"integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
+			"dev": true,
+			"requires": {
+				"imurmurhash": "0.1.4"
+			}
 		},
 		"unique-string": {
 			"version": "1.0.0",
@@ -2264,10 +7989,62 @@
 				"crypto-random-string": "1.0.0"
 			}
 		},
+		"unset-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+			"dev": true,
+			"requires": {
+				"has-value": "0.3.1",
+				"isobject": "3.0.1"
+			},
+			"dependencies": {
+				"has-value": {
+					"version": "0.3.1",
+					"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+					"dev": true,
+					"requires": {
+						"get-value": "2.0.6",
+						"has-values": "0.1.4",
+						"isobject": "2.1.0"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+							"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+							"dev": true,
+							"requires": {
+								"isarray": "1.0.0"
+							}
+						}
+					}
+				},
+				"has-values": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+					"dev": true
+				}
+			}
+		},
+		"untildify": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.2.tgz",
+			"integrity": "sha1-fx8wIFWz/qDz6B3HjrNnZstl4/E=",
+			"dev": true
+		},
 		"unzip-response": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
 			"integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
+			"dev": true
+		},
+		"upath": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/upath/-/upath-1.0.4.tgz",
+			"integrity": "sha512-d4SJySNBXDaQp+DPrziv3xGS6w3d2Xt69FijJr86zMPBy23JEloMCEOUBBzuN7xCtjLCnmB9tI/z7SBCahHBOw==",
 			"dev": true
 		},
 		"update-notifier": {
@@ -2286,6 +8063,29 @@
 				"semver-diff": "2.1.0",
 				"xdg-basedir": "3.0.0"
 			}
+		},
+		"uri-js": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-3.0.2.tgz",
+			"integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
+			"dev": true,
+			"requires": {
+				"punycode": "2.1.0"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+					"integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
+					"dev": true
+				}
+			}
+		},
+		"urix": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+			"dev": true
 		},
 		"url": {
 			"version": "0.11.0",
@@ -2314,6 +8114,21 @@
 				"prepend-http": "1.0.4"
 			}
 		},
+		"url-to-options": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
+			"integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
+			"dev": true
+		},
+		"use": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
+			"integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
+			"dev": true,
+			"requires": {
+				"kind-of": "6.0.2"
+			}
+		},
 		"util": {
 			"version": "0.10.3",
 			"resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
@@ -2337,6 +8152,12 @@
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 			"dev": true
 		},
+		"v8-compile-cache": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-1.1.2.tgz",
+			"integrity": "sha512-ejdrifsIydN1XDH7EuR2hn8ZrkRKUYF7tUcBjBy/lhrCvs2K+zRlbW9UHc0IQ9RsYFZJFqJrieoIHfkCa0DBRA==",
+			"dev": true
+		},
 		"validate-npm-package-license": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
@@ -2345,6 +8166,39 @@
 			"requires": {
 				"spdx-correct": "3.0.0",
 				"spdx-expression-parse": "3.0.0"
+			}
+		},
+		"vinyl": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+			"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+			"dev": true,
+			"requires": {
+				"clone": "1.0.4",
+				"clone-stats": "0.0.1",
+				"replace-ext": "0.0.1"
+			}
+		},
+		"vinyl-file": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-2.0.0.tgz",
+			"integrity": "sha1-p+v1/779obfRjRQPyweyI++2dRo=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1",
+				"strip-bom": "2.0.0",
+				"strip-bom-stream": "2.0.0",
+				"vinyl": "1.2.0"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+					"dev": true
+				}
 			}
 		},
 		"vm-browserify": {
@@ -2356,6 +8210,309 @@
 				"indexof": "0.0.1"
 			}
 		},
+		"watchpack": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.5.0.tgz",
+			"integrity": "sha512-RSlipNQB1u48cq0wH/BNfCu1tD/cJ8ydFIkNYhp9o+3d+8unClkIovpW5qpFPgmL9OE48wfAnlZydXByWP82AA==",
+			"dev": true,
+			"requires": {
+				"chokidar": "2.0.3",
+				"graceful-fs": "4.1.11",
+				"neo-async": "2.5.0"
+			}
+		},
+		"webpack": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.2.0.tgz",
+			"integrity": "sha512-O/KmJ2MYoSfsZzq3//RyyYICYTb1gPAuYSIoD4XbxWFqkDrZCkF8BIAwPuFjA8SFqTcsIL3gTS7hiTZaUN2Tjw==",
+			"dev": true,
+			"requires": {
+				"acorn": "5.5.3",
+				"acorn-dynamic-import": "3.0.0",
+				"ajv": "6.4.0",
+				"ajv-keywords": "3.1.0",
+				"chrome-trace-event": "0.1.2",
+				"enhanced-resolve": "4.0.0",
+				"eslint-scope": "3.7.1",
+				"loader-runner": "2.3.0",
+				"loader-utils": "1.1.0",
+				"memory-fs": "0.4.1",
+				"micromatch": "3.1.10",
+				"mkdirp": "0.5.1",
+				"neo-async": "2.5.0",
+				"node-libs-browser": "2.1.0",
+				"schema-utils": "0.4.5",
+				"tapable": "1.0.0",
+				"uglifyjs-webpack-plugin": "1.2.4",
+				"watchpack": "1.5.0",
+				"webpack-sources": "1.1.0"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "5.5.3",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+					"integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
+					"dev": true
+				}
+			}
+		},
+		"webpack-addons": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/webpack-addons/-/webpack-addons-1.1.5.tgz",
+			"integrity": "sha512-MGO0nVniCLFAQz1qv22zM02QPjcpAoJdy7ED0i3Zy7SY1IecgXCm460ib7H/Wq7e9oL5VL6S2BxaObxwIcag0g==",
+			"dev": true,
+			"requires": {
+				"jscodeshift": "0.4.1"
+			},
+			"dependencies": {
+				"arr-diff": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+					"dev": true,
+					"requires": {
+						"arr-flatten": "1.1.0"
+					}
+				},
+				"array-unique": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+					"dev": true
+				},
+				"ast-types": {
+					"version": "0.10.1",
+					"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.10.1.tgz",
+					"integrity": "sha512-UY7+9DPzlJ9VM8eY0b2TUZcZvF+1pO0hzMtAyjBYKhOmnvRlqYNYnWdtsMj0V16CGaMlpL0G1jnLbLo4AyotuQ==",
+					"dev": true
+				},
+				"babylon": {
+					"version": "6.18.0",
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+					"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+					"dev": true
+				},
+				"braces": {
+					"version": "1.8.5",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+					"dev": true,
+					"requires": {
+						"expand-range": "1.8.2",
+						"preserve": "0.2.0",
+						"repeat-element": "1.1.2"
+					}
+				},
+				"expand-brackets": {
+					"version": "0.1.5",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+					"dev": true,
+					"requires": {
+						"is-posix-bracket": "0.1.1"
+					}
+				},
+				"extglob": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+					"dev": true,
+					"requires": {
+						"is-extglob": "1.0.0"
+					}
+				},
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true,
+					"requires": {
+						"is-extglob": "1.0.0"
+					}
+				},
+				"jscodeshift": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.4.1.tgz",
+					"integrity": "sha512-iOX6If+hsw0q99V3n31t4f5VlD1TQZddH08xbT65ZqA7T4Vkx68emrDZMUOLVvCEAJ6NpAk7DECe3fjC/t52AQ==",
+					"dev": true,
+					"requires": {
+						"async": "1.5.2",
+						"babel-plugin-transform-flow-strip-types": "6.22.0",
+						"babel-preset-es2015": "6.24.1",
+						"babel-preset-stage-1": "6.24.1",
+						"babel-register": "6.26.0",
+						"babylon": "6.18.0",
+						"colors": "1.2.1",
+						"flow-parser": "0.68.0",
+						"lodash": "4.17.5",
+						"micromatch": "2.3.11",
+						"node-dir": "0.1.8",
+						"nomnom": "1.8.1",
+						"recast": "0.12.9",
+						"temp": "0.8.3",
+						"write-file-atomic": "1.3.4"
+					}
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "1.1.6"
+					}
+				},
+				"micromatch": {
+					"version": "2.3.11",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+					"dev": true,
+					"requires": {
+						"arr-diff": "2.0.0",
+						"array-unique": "0.2.1",
+						"braces": "1.8.5",
+						"expand-brackets": "0.1.5",
+						"extglob": "0.3.2",
+						"filename-regex": "2.0.1",
+						"is-extglob": "1.0.0",
+						"is-glob": "2.0.1",
+						"kind-of": "3.2.2",
+						"normalize-path": "2.1.1",
+						"object.omit": "2.0.1",
+						"parse-glob": "3.0.4",
+						"regex-cache": "0.4.4"
+					}
+				},
+				"recast": {
+					"version": "0.12.9",
+					"resolved": "https://registry.npmjs.org/recast/-/recast-0.12.9.tgz",
+					"integrity": "sha512-y7ANxCWmMW8xLOaiopiRDlyjQ9ajKRENBH+2wjntIbk3A6ZR1+BLQttkmSHMY7Arl+AAZFwJ10grg2T6f1WI8A==",
+					"dev": true,
+					"requires": {
+						"ast-types": "0.10.1",
+						"core-js": "2.5.3",
+						"esprima": "4.0.0",
+						"private": "0.1.8",
+						"source-map": "0.6.1"
+					}
+				},
+				"write-file-atomic": {
+					"version": "1.3.4",
+					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+					"integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"imurmurhash": "0.1.4",
+						"slide": "1.1.6"
+					}
+				}
+			}
+		},
+		"webpack-cli": {
+			"version": "2.0.13",
+			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-2.0.13.tgz",
+			"integrity": "sha512-0lnOi3yla8FsZVuMsbfnNRB/8DlfuDugKdekC+4ykydZG0+UOidMi5J5LLWN4c0VJ8PqC19yMXXkYyCq78OuqA==",
+			"dev": true,
+			"requires": {
+				"chalk": "2.3.2",
+				"cross-spawn": "6.0.5",
+				"diff": "3.5.0",
+				"enhanced-resolve": "4.0.0",
+				"glob-all": "3.1.0",
+				"global-modules": "1.0.0",
+				"got": "8.3.0",
+				"inquirer": "5.1.0",
+				"interpret": "1.1.0",
+				"jscodeshift": "0.5.0",
+				"listr": "0.13.0",
+				"loader-utils": "1.1.0",
+				"lodash": "4.17.5",
+				"log-symbols": "2.2.0",
+				"mkdirp": "0.5.1",
+				"p-each-series": "1.0.0",
+				"p-lazy": "1.0.0",
+				"prettier": "1.11.1",
+				"resolve-cwd": "2.0.0",
+				"supports-color": "5.3.0",
+				"v8-compile-cache": "1.1.2",
+				"webpack-addons": "1.1.5",
+				"yargs": "11.0.0",
+				"yeoman-environment": "2.0.5",
+				"yeoman-generator": "2.0.3"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "6.0.5",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+					"dev": true,
+					"requires": {
+						"nice-try": "1.0.4",
+						"path-key": "2.0.1",
+						"semver": "5.5.0",
+						"shebang-command": "1.2.0",
+						"which": "1.3.0"
+					}
+				},
+				"got": {
+					"version": "8.3.0",
+					"resolved": "https://registry.npmjs.org/got/-/got-8.3.0.tgz",
+					"integrity": "sha512-kBNy/S2CGwrYgDSec5KTWGKUvupwkkTVAjIsVFF2shXO13xpZdFP4d4kxa//CLX2tN/rV0aYwK8vY6UKWGn2vQ==",
+					"dev": true,
+					"requires": {
+						"@sindresorhus/is": "0.7.0",
+						"cacheable-request": "2.1.4",
+						"decompress-response": "3.3.0",
+						"duplexer3": "0.1.4",
+						"get-stream": "3.0.0",
+						"into-stream": "3.1.0",
+						"is-retry-allowed": "1.1.0",
+						"isurl": "1.0.0",
+						"lowercase-keys": "1.0.0",
+						"mimic-response": "1.0.0",
+						"p-cancelable": "0.4.0",
+						"p-timeout": "2.0.1",
+						"pify": "3.0.0",
+						"safe-buffer": "5.1.1",
+						"timed-out": "4.0.1",
+						"url-parse-lax": "3.0.0",
+						"url-to-options": "1.0.1"
+					}
+				},
+				"prepend-http": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+					"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+					"dev": true
+				},
+				"url-parse-lax": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+					"integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+					"dev": true,
+					"requires": {
+						"prepend-http": "2.0.0"
+					}
+				}
+			}
+		},
+		"webpack-sources": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
+			"integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
+			"dev": true,
+			"requires": {
+				"source-list-map": "2.0.0",
+				"source-map": "0.6.1"
+			}
+		},
 		"which": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
@@ -2365,6 +8522,12 @@
 				"isexe": "2.0.0"
 			}
 		},
+		"which-module": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+			"dev": true
+		},
 		"widest-line": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
@@ -2372,6 +8535,62 @@
 			"dev": true,
 			"requires": {
 				"string-width": "2.1.1"
+			}
+		},
+		"worker-farm": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.6.0.tgz",
+			"integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
+			"dev": true,
+			"requires": {
+				"errno": "0.1.7"
+			}
+		},
+		"wrap-ansi": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+			"dev": true,
+			"requires": {
+				"string-width": "1.0.2",
+				"strip-ansi": "3.0.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"dev": true,
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"dev": true,
+					"requires": {
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				}
 			}
 		},
 		"wrappy": {
@@ -2403,11 +8622,245 @@
 			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
 			"dev": true
 		},
+		"y18n": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+			"dev": true
+		},
 		"yallist": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
 			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
 			"dev": true
+		},
+		"yargs": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
+			"integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
+			"dev": true,
+			"requires": {
+				"cliui": "4.0.0",
+				"decamelize": "1.2.0",
+				"find-up": "2.1.0",
+				"get-caller-file": "1.0.2",
+				"os-locale": "2.1.0",
+				"require-directory": "2.1.1",
+				"require-main-filename": "1.0.1",
+				"set-blocking": "2.0.0",
+				"string-width": "2.1.1",
+				"which-module": "2.0.0",
+				"y18n": "3.2.1",
+				"yargs-parser": "9.0.2"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"dev": true,
+					"requires": {
+						"locate-path": "2.0.0"
+					}
+				},
+				"y18n": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+					"dev": true
+				}
+			}
+		},
+		"yargs-parser": {
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+			"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+			"dev": true,
+			"requires": {
+				"camelcase": "4.1.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+					"dev": true
+				}
+			}
+		},
+		"yeoman-environment": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.0.5.tgz",
+			"integrity": "sha512-6/W7/B54OPHJXob0n0+pmkwFsirC8cokuQkPSmT/D0lCcSxkKtg/BA6ZnjUBIwjuGqmw3DTrT4en++htaUju5g==",
+			"dev": true,
+			"requires": {
+				"chalk": "2.3.2",
+				"debug": "3.1.0",
+				"diff": "3.5.0",
+				"escape-string-regexp": "1.0.5",
+				"globby": "6.1.0",
+				"grouped-queue": "0.3.3",
+				"inquirer": "3.3.0",
+				"is-scoped": "1.0.0",
+				"lodash": "4.17.5",
+				"log-symbols": "2.2.0",
+				"mem-fs": "1.1.3",
+				"text-table": "0.2.0",
+				"untildify": "3.0.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"inquirer": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+					"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+					"dev": true,
+					"requires": {
+						"ansi-escapes": "3.1.0",
+						"chalk": "2.3.2",
+						"cli-cursor": "2.1.0",
+						"cli-width": "2.2.0",
+						"external-editor": "2.1.0",
+						"figures": "2.0.0",
+						"lodash": "4.17.5",
+						"mute-stream": "0.0.7",
+						"run-async": "2.3.0",
+						"rx-lite": "4.0.8",
+						"rx-lite-aggregates": "4.0.8",
+						"string-width": "2.1.1",
+						"strip-ansi": "4.0.0",
+						"through": "2.3.8"
+					}
+				}
+			}
+		},
+		"yeoman-generator": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-2.0.3.tgz",
+			"integrity": "sha512-mODmrZ26a94djmGZZuIiomSGlN4wULdou29ZwcySupb2e9FdvoCl7Ps2FqHFjEHio3kOl/iBeaNqrnx3C3NwWg==",
+			"dev": true,
+			"requires": {
+				"async": "2.6.0",
+				"chalk": "2.3.2",
+				"cli-table": "0.3.1",
+				"cross-spawn": "5.1.0",
+				"dargs": "5.1.0",
+				"dateformat": "3.0.3",
+				"debug": "3.1.0",
+				"detect-conflict": "1.0.1",
+				"error": "7.0.2",
+				"find-up": "2.1.0",
+				"github-username": "4.1.0",
+				"istextorbinary": "2.2.1",
+				"lodash": "4.17.5",
+				"make-dir": "1.2.0",
+				"mem-fs-editor": "3.0.2",
+				"minimist": "1.2.0",
+				"pretty-bytes": "4.0.2",
+				"read-chunk": "2.1.0",
+				"read-pkg-up": "3.0.0",
+				"rimraf": "2.6.2",
+				"run-async": "2.3.0",
+				"shelljs": "0.8.1",
+				"text-table": "0.2.0",
+				"through2": "2.0.3",
+				"yeoman-environment": "2.0.5"
+			},
+			"dependencies": {
+				"async": {
+					"version": "2.6.0",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+					"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+					"dev": true,
+					"requires": {
+						"lodash": "4.17.5"
+					}
+				},
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"dev": true,
+					"requires": {
+						"locate-path": "2.0.0"
+					}
+				},
+				"load-json-file": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"parse-json": "4.0.0",
+						"pify": "3.0.0",
+						"strip-bom": "3.0.0"
+					}
+				},
+				"parse-json": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+					"dev": true,
+					"requires": {
+						"error-ex": "1.3.1",
+						"json-parse-better-errors": "1.0.1"
+					}
+				},
+				"path-type": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+					"dev": true,
+					"requires": {
+						"pify": "3.0.0"
+					}
+				},
+				"read-pkg": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+					"dev": true,
+					"requires": {
+						"load-json-file": "4.0.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "3.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+					"dev": true,
+					"requires": {
+						"find-up": "2.1.0",
+						"read-pkg": "3.0.0"
+					}
+				},
+				"strip-bom": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+					"dev": true
+				}
+			}
 		}
 	}
 }

--- a/packages/ste-browser/package.json
+++ b/packages/ste-browser/package.json
@@ -3,7 +3,9 @@
   "version": "1.3.11",
   "description": "Add the power of events directly to your client projects. This version of Strongly Typed Events works in the browser.",
   "scripts": {
-    "build": "del-cli ./lib & browserify ./src/ste-core.js -o ./dist/ste-core.js & uglifyjs ./dist/ste-core.js --source-map -o ./dist/ste-core.min.js & browserify ./src/ste-events.js -o ./dist/ste-events.js & uglifyjs ./dist/ste-events.js --source-map -o ./dist/ste-events.min.js & browserify ./src/ste-simple-events.js -o ./dist/ste-simple-events.js & uglifyjs ./dist/ste-simple-events.js --source-map -o ./dist/ste-simple-events.min.js & browserify ./src/ste-signals.js -o ./dist/ste-signals.js & uglifyjs ./dist/ste-signals.js --source-map -o ./dist/ste-signals.min.js & browserify ./src/strongly-typed-events.js -o ./dist/strongly-typed-events.js & uglifyjs ./dist/strongly-typed-events.js --source-map -o ./dist/strongly-typed-events.min.js"
+    "webpack:dev": "webpack --mode=development",
+    "webpack:prod": "webpack --mode=production --output-filename=[name].min.js",
+    "build": "del-cli ./dist && npm run webpack:prod"
   },
   "repository": {
     "type": "git",
@@ -35,7 +37,8 @@
     "ste-signals": "^1.3.11",
     "ste-simple-events": "^1.3.11",
     "strongly-typed-events": "^1.3.11",
-    "uglify-js": "^3.3.13"
+    "webpack": "^4.2.0",
+    "webpack-cli": "^2.0.13"
   },
   "engines": {
     "node": ">=4.2.4"

--- a/packages/ste-browser/webpack.config.js
+++ b/packages/ste-browser/webpack.config.js
@@ -1,0 +1,42 @@
+var webpack = require('webpack');
+
+var output = {
+  path: __dirname + '/dist',
+  libraryTarget: 'umd',
+  umdNamedDefine: false
+};
+
+module.exports = [
+  {
+    entry: {
+      'ste-core': './src/ste-core.js',
+    },
+    output: output,
+    devtool: 'source-map'
+  },
+  {
+    entry: {
+      'ste-events': './src/ste-events.js',
+      'ste-signals': './src/ste-signals.js',
+      'ste-simple-events': './src/ste-simple-events.js'
+    },
+    output: output,
+    externals: [
+      'ste-core'
+    ],
+    devtool: 'source-map'
+  },
+  {
+    entry: {
+      'strongly-typed-events': './src/strongly-typed-events.js'
+    },
+    output: output,
+    externals: [
+      'ste-core',
+      'ste-events',
+      'ste-signals',
+      'ste-simple-events'
+    ],
+    devtool: 'source-map'
+  }
+];

--- a/packages/ste-browser/webpack.config.js
+++ b/packages/ste-browser/webpack.config.js
@@ -10,6 +10,7 @@ module.exports = [
   {
     entry: {
       'ste-core': './src/ste-core.js',
+      'strongly-typed-events': './src/strongly-typed-events.js'
     },
     output: output,
     devtool: 'source-map'
@@ -23,19 +24,6 @@ module.exports = [
     output: output,
     externals: [
       'ste-core'
-    ],
-    devtool: 'source-map'
-  },
-  {
-    entry: {
-      'strongly-typed-events': './src/strongly-typed-events.js'
-    },
-    output: output,
-    externals: [
-      'ste-core',
-      'ste-events',
-      'ste-signals',
-      'ste-simple-events'
     ],
     devtool: 'source-map'
   }


### PR DESCRIPTION
Replacing browserify with webpack to generate UMD bundles.

ste-events, ste-signals and simple-events have ste-core as an external. To use these files you'll need to include ste-core first. This makes these three bundles lighter.

----

 Checkout my fork and try it out. Suggest changes or implement it using my PR as an example.