### PR TITLE
Added NonUniformEventList and Test

### DIFF
--- a/packages/ste-events/src/events.ts
+++ b/packages/ste-events/src/events.ts
@@ -43,6 +43,50 @@ export class EventDispatcher<TSender, TArgs>
 }
 
 /**
+ * Similar to EventList, but instead of TArgs, a map of event names ang argument types is provided with TArgsMap.
+ */
+export class NonUniformEventList<
+  TSender,
+  TArgsMap extends { [event: string]: any }
+> {
+  private _events: {
+    [K in keyof TArgsMap]?: EventDispatcher<TSender, TArgsMap[K]>
+  } = {};
+
+  /**
+   * Gets the dispatcher associated with the name.
+   * @param name The name of the event.
+   */
+  get<K extends keyof TArgsMap>(
+    name: K
+  ): EventDispatcher<TSender, TArgsMap[K]> {
+    if (this._events[name]) {
+      // @TODO avoid typecasting. Not sure why TS thinks this._events[name] could still be undefined.
+      return this._events[name] as EventDispatcher<TSender, TArgsMap[K]>;
+    }
+
+    const event = this.createDispatcher<TArgsMap[K]>();
+    this._events[name] = event;
+    return event;
+  }
+
+  /**
+   * Removes the dispatcher associated with the name.
+   * @param name The name of the event.
+   */
+  remove(name: string): void {
+    delete this._events[name];
+  }
+
+  /**
+   * Creates a new dispatcher instance.
+   */
+  protected createDispatcher<T>(): EventDispatcher<TSender, T> {
+    return new EventDispatcher<TSender, T>();
+  }
+}
+
+/**
  * Storage class for multiple events that are accessible by name.
  * Events dispatchers are automatically created.
  */

--- a/packages/ste-events/src/index.ts
+++ b/packages/ste-events/src/index.ts
@@ -1,2 +1,2 @@
-export { EventDispatcher, EventHandlingBase, EventList } from "./events";
+export { EventDispatcher, EventHandlingBase, EventList, NonUniformEventList } from "./events";
 export { IEventHandler, IEventHandling, IEvent } from "./definitions";

--- a/packages/ste-events/test/event-test.ts
+++ b/packages/ste-events/test/event-test.ts
@@ -1,7 +1,7 @@
 "use strict";
 
 import { expect } from "chai";
-import { EventDispatcher, EventList } from "../src/";
+import { EventDispatcher, EventList, NonUniformEventList } from "../src/";
 
 class Dummy {
   constructor(name: string) {}
@@ -340,6 +340,76 @@ describe("Strongly Typed Events - Event", function() {
       expect(result, "Event 1 should still be present.").to.equal(true);
 
       result = list.get(event2).has(fn);
+      expect(result, "Event 2 should not be present.").to.equal(false);
+    });
+  });
+
+  describe("NonUniformEventList", function() {
+    it("Subscribe to event name", function() {
+      type ArgMap = {"myEvent": number};
+      let list = new NonUniformEventList<Dummy, ArgMap>();
+      var fn = (dummy: Dummy, nr: number) => {};
+
+      list.get("myEvent").subscribe(fn);
+      var result = list.get("myEvent").has(fn);
+      expect(result, "result should be true.").to.equals(true);
+    });
+
+    it("Unsubscribe to event name", function() {
+      type ArgMap = {"myEvent": number};
+      let list = new NonUniformEventList<Dummy, ArgMap>();
+      var fn = (dummy: Dummy, nr: number) => {};
+
+      list.get("myEvent").subscribe(fn);
+      list.get("myEvent").unsubscribe(fn);
+
+      var result = list.get("myEvent").has(fn);
+      expect(result, "result should be false due to unsubscribe.").to.equals(
+        false
+      );
+    });
+
+    it("Test firing two events in one list", function() {
+      type ArgMap = {"ev1": number, "ev2": number};
+      let list = new NonUniformEventList<Dummy | null, ArgMap>();
+      let result = "";
+
+      var fn1 = (dummy: Dummy | null, nr: number) => {
+        result = "ev1:" + nr;
+      };
+
+      var fn2 = (dummy: Dummy | null, nr: number) => {
+        result = "ev2:" + nr;
+      };
+
+      list.get("ev1").subscribe(fn1);
+      list.get("ev2").subscribe(fn2);
+
+      list.get("ev2").dispatch(null, 16);
+      expect(result, 'Result should be "ev2:16.').to.equal("ev2:16");
+
+      list.get("ev1").dispatch(null, 8);
+      expect(result, 'Result should be "ev1:8.').to.equal("ev1:8");
+    });
+
+    it("Test remove from list.", function() {
+      type ArgMap = {"ev1": number, "ev2": number};
+      let list = new NonUniformEventList<Dummy, ArgMap>();
+      var fn = (dummy: Dummy, nr: number) => {};
+
+      list.get("ev1").subscribe(fn);
+
+      list.get("ev2").subscribe(fn);
+
+      let result = list.get("ev2").has(fn);
+      expect(result, "Event 2 should be present.").to.equal(true);
+
+      list.remove("ev2");
+
+      result = list.get("ev1").has(fn);
+      expect(result, "Event 1 should still be present.").to.equal(true);
+
+      result = list.get("ev2").has(fn);
       expect(result, "Event 2 should not be present.").to.equal(false);
     });
   });


### PR DESCRIPTION
This merge is to show how a NonUniformEventList class would work. It's intended to be exactly the same as an EventList but with different typings that enforce event names and non-uniform event arguments.