### PR TITLE
Remove circular imports from ste-core

### DIFF
--- a/packages/ste-core/src/dispatching/DispatcherBase.ts
+++ b/packages/ste-core/src/dispatching/DispatcherBase.ts
@@ -1,13 +1,10 @@
-import {
-    ISubscribable,
-    DispatcherWrapper,
-    SubscriptionChangeEventDispatcher,
-    ISubscription,
-    IPropagationStatus,
-    EventManagement,
-    Subscription,
-    SubscriptionChangeEventHandler,
-} from "..";
+import type { ISubscribable } from "../events/ISubscribable";
+import type { ISubscription } from "../events/ISubscription";
+import type { SubscriptionChangeEventHandler } from "./SubscriptionChangeEventHandler";
+import { DispatcherWrapper } from "./DispatcherWrapper";
+import type { IPropagationStatus } from "./IPropagationStatus";
+import { Subscription } from "../events/Subscription";
+import { EventManagement } from "../management/EventManagement";
 
 /**
  * Base class for implementation of the dispatcher. It facilitates the subscribe
@@ -281,3 +278,27 @@ export abstract class DispatcherBase<TEventHandler>
         }
     }
 }
+
+
+/**
+ * Dispatcher for subscription changes.
+ *
+ * @export
+ * @class SubscriptionChangeEventDispatcher
+ * @extends {DispatcherBase<SubscriptionChangeEventHandler>}
+ */
+
+ export class SubscriptionChangeEventDispatcher extends DispatcherBase<SubscriptionChangeEventHandler>
+ {
+     /**
+      * Dispatches the event.
+      *
+      * @param {number} count The currrent number of subscriptions.
+      *
+      * @memberOf SubscriptionChangeEventDispatcher
+      */
+     public dispatch(count: number) {
+         this._dispatch(false, this, arguments);
+     }
+ }
+ 

--- a/packages/ste-core/src/dispatching/PromiseDispatcherBase.ts
+++ b/packages/ste-core/src/dispatching/PromiseDispatcherBase.ts
@@ -1,11 +1,9 @@
-import {
-    DispatcherBase,
-    IPropagationStatus,
-    DispatchError,
-    EventManagement,
-    PromiseSubscription,
-    ISubscription,
-} from "..";
+import type { ISubscription } from "../events/ISubscription";
+import { PromiseSubscription } from "../events/PromiseSubscription";
+import { EventManagement } from "../management/EventManagement";
+import { DispatcherBase } from "./DispatcherBase";
+import { DispatchError } from "./DispatchError";
+import type { IPropagationStatus } from "./IPropagationStatus";
 
 /**
  * Dispatcher base for dispatchers that use promises. Each promise

--- a/packages/ste-core/src/dispatching/SubscriptionChangeEventHandler.ts
+++ b/packages/ste-core/src/dispatching/SubscriptionChangeEventHandler.ts
@@ -1,27 +1,5 @@
-import { DispatcherBase } from "..";
 
 /**
  * Event handler type definition for subscription changes.
  */
 export type SubscriptionChangeEventHandler = (count: number) => void;
-
-/**
- * Dispatcher for subscription changes.
- * 
- * @export
- * @class SubscriptionChangeEventDispatcher
- * @extends {DispatcherBase<SubscriptionChangeEventHandler>}
- */
-export class SubscriptionChangeEventDispatcher extends DispatcherBase<SubscriptionChangeEventHandler>
-{
-    /**
-     * Dispatches the event.
-     * 
-     * @param {number} count The currrent number of subscriptions.
-     * 
-     * @memberOf SubscriptionChangeEventDispatcher
-     */
-    public dispatch(count: number){
-        this._dispatch(false, this, arguments);
-    }
-}

--- a/packages/ste-core/src/index.ts
+++ b/packages/ste-core/src/index.ts
@@ -7,7 +7,7 @@
  * Released under the MIT license
  */
 
-import { DispatcherBase } from './dispatching/DispatcherBase';
+import { DispatcherBase, SubscriptionChangeEventDispatcher } from './dispatching/DispatcherBase';
 import { DispatchError } from './dispatching/DispatchError';
 import { DispatcherWrapper } from './dispatching/DispatcherWrapper';
 import { EventListBase } from './dispatching/EventListBase';
@@ -21,7 +21,7 @@ import { ISubscription } from './events/ISubscription';
 import { PromiseDispatcherBase } from './dispatching/PromiseDispatcherBase';
 import { PromiseSubscription } from './events/PromiseSubscription';
 import { Subscription } from './events/Subscription';
-import { SubscriptionChangeEventDispatcher, SubscriptionChangeEventHandler } from './dispatching/SubscriptionChangeEventHandler';
+import { SubscriptionChangeEventHandler } from './dispatching/SubscriptionChangeEventHandler';
 
 export {
     IEventManagement,

--- a/packages/ste-promise-signals/src/PromiseSignalHandlingBase.ts
+++ b/packages/ste-promise-signals/src/PromiseSignalHandlingBase.ts
@@ -1,5 +1,5 @@
 import { HandlingBase } from "ste-core";
-import { PromiseSignalDispatcher } from ".";
+import { PromiseSignalDispatcher } from "./PromiseSignalDispatcher";
 import { IPromiseSignalHandler } from "./IPromiseSignalHandler";
 import { IPromiseSignalHandling } from "./IPromiseSignalHandling";
 import { PromiseSignalList } from "./PromiseSignalList";

--- a/packages/ste-promise-signals/src/PromiseSignalList.ts
+++ b/packages/ste-promise-signals/src/PromiseSignalList.ts
@@ -1,5 +1,5 @@
 import { EventListBase } from "ste-core";
-import { PromiseSignalDispatcher } from ".";
+import { PromiseSignalDispatcher } from "./PromiseSignalDispatcher";
 
 /**
  * Storage class for multiple signal events that are accessible by name.

--- a/packages/ste-signals/src/SignalHandlingBase.ts
+++ b/packages/ste-signals/src/SignalHandlingBase.ts
@@ -1,10 +1,8 @@
 import { HandlingBase } from "ste-core";
-import {
-    ISignalHandler,
-    ISignalHandling,
-    SignalDispatcher,
-    SignalList,
-} from ".";
+import type { ISignalHandler, ISignalHandling } from ".";
+import { SignalDispatcher } from "./SignalDispatcher";
+import { SignalList } from "./SignalList";
+
 
 /**
  * Extends objects with signal event handling capabilities.

--- a/packages/ste-signals/src/SignalList.ts
+++ b/packages/ste-signals/src/SignalList.ts
@@ -1,5 +1,5 @@
 import { EventListBase } from "ste-core";
-import { SignalDispatcher } from ".";
+import { SignalDispatcher } from "./SignalDispatcher";
 
 /**
  * Storage class for multiple signal events that are accessible by name.


### PR DESCRIPTION
This is a lot less clean, but prevents errors from Vite builds, like in #269 .

To be honest, there might be a better solution to this, but this is what my meagre TypeScript skills could come up with. In particular, I could not work out how to keep `DispatcherBase` and `SubscriptionChangeEventDispatcher ` in separate files since they depend on each other.

Also this is my first time with a Lerna repo, so apologies if something isn't right.